### PR TITLE
Added ROOT dictionary for std::vector<art::Ptr<recob::Cluster>>.

### DIFF
--- a/lardataobj/RecoBase/classes_def.xml
+++ b/lardataobj/RecoBase/classes_def.xml
@@ -163,6 +163,7 @@
   <class name="art::PtrVector<recob::OpFlash>"/>
   <class name="art::PtrVector<recob::TrackFitHitInfo>"/>
   <class name="art::PtrVector<recob::MCSFitResult>"/>
+  <class name="std::vector<art::Ptr<recob::Cluster>>"/>
   <class name="std::vector< art::PtrVector<recob::Cluster>>"/>
   <class name="std::vector< art::PtrVector<recob::TrackFitHitInfo>>"/>
 
@@ -205,6 +206,7 @@
   <class name="art::Wrapper< std::vector< recob::OpFlash>>"/>
   <class name="art::Wrapper< std::vector< recob::MCSFitResult>>"/>
   <class name="art::Wrapper< std::vector< art::PtrVector<recob::Cluster>>>"/>
+  <class name="art::Wrapper< std::vector< art::Ptr<recob::Cluster>>>"/>
   <class name="art::Wrapper< std::vector< std::vector<recob::TrackFitHitInfo>>>"/>
 
   <!-- io rules for types in this file -->


### PR DESCRIPTION
For storage of selected clusters, I require `std::vector<art::Ptr<recob::Cluster>>`.
This request will enable the creation of the ROOT dictionaries needed to serialise such data structure.

Why not the already supported `art::PtrVector<recob::Cluster>`?
--------------------------------------------------------------------------------------

My use case allows cluster objects to come from different data products, and it is my understanding that all the elements of a `art::PtrVector` must belong to the same one.

Why not in the experiment repository?
----------------------------------------------------

The class does not depend on anything specific to the experiment, so `lardataobj` is its natural place.
In addition, this strategy avoids conflicts by "preventing" the same definition from appearing in different repositories (but see *Breaking change* below).


Breaking change
------------------------

No breaking change, unless some experiment repository has _already_ added the same dictionary on their own, in which case runtime issues might arise.


