### PR TITLE
Added x location component to recob::OpFlash data product

### DIFF
--- a/lardataobj/RecoBase/OpFlash.cxx
+++ b/lardataobj/RecoBase/OpFlash.cxx
@@ -18,6 +18,7 @@ namespace recob{
   OpFlash::OpFlash(double time, double timewidth, double abstime, unsigned int frame,
 		   std::vector<double> PEperOpDet,
 		   bool InBeamFrame, int onBeamTime, double FastToTotal,
+		   double xCenter, double xWidth,
 		   double yCenter, double yWidth,
 		   double zCenter, double zWidth,
 		   std::vector<double> WireCenters,
@@ -29,6 +30,8 @@ namespace recob{
     , fPEperOpDet  { std::move(PEperOpDet) }
     , fWireCenters { std::move(WireCenters) }
     , fWireWidths  { std::move(WireWidths) }
+    , fXCenter     { xCenter }
+    , fXWidth      { xWidth }
     , fYCenter     { yCenter }
     , fYWidth      { yWidth }
     , fZCenter     { zCenter }
@@ -38,6 +41,22 @@ namespace recob{
     , fOnBeamTime  { onBeamTime }
   {
   }
+
+  //----------------------------------------------------------------------
+  OpFlash::OpFlash(double time, double timewidth, double abstime, unsigned int frame,
+		   std::vector<double> PEperOpDet,
+		   bool InBeamFrame, int onBeamTime, double FastToTotal,
+		   double yCenter, double yWidth,
+		   double zCenter, double zWidth,
+		   std::vector<double> WireCenters,
+		   std::vector<double> WireWidths)
+    : OpFlash{
+      time, timewidth, abstime, frame,
+      std::move(PEperOpDet), InBeamFrame, onBeamTime, FastToTotal,
+      NoCenter, NoCenter, yCenter, yWidth, zCenter, zWidth,
+      std::move(WireCenters), std::move(WireWidths)
+      }
+    {}
 
   //----------------------------------------------------------------------
   bool operator < (const OpFlash & a, const OpFlash & b)

--- a/lardataobj/RecoBase/OpFlash.cxx
+++ b/lardataobj/RecoBase/OpFlash.cxx
@@ -9,16 +9,10 @@
 
 #include "lardataobj/RecoBase/OpFlash.h"
 
-#include <cstddef> // std::size_t
+#include <numeric> // std::accumulate()
+#include <utility> // std::move()
 
 namespace recob{
-
-  //----------------------------------------------------------------------
-  OpFlash::OpFlash()
-    : fTime(            0.      )
-  {
-
-  }
 
   //----------------------------------------------------------------------
   OpFlash::OpFlash(double time, double timewidth, double abstime, unsigned int frame,
@@ -28,22 +22,21 @@ namespace recob{
 		   double zCenter, double zWidth,
 		   std::vector<double> WireCenters,
 		   std::vector<double> WireWidths)
+    : fTime        { time }
+    , fTimeWidth   { timewidth }
+    , fAbsTime     { abstime }
+    , fFrame       { frame }
+    , fPEperOpDet  { std::move(PEperOpDet) }
+    , fWireCenters { std::move(WireCenters) }
+    , fWireWidths  { std::move(WireWidths) }
+    , fYCenter     { yCenter }
+    , fYWidth      { yWidth }
+    , fZCenter     { zCenter }
+    , fZWidth      { zWidth }
+    , fFastToTotal { FastToTotal }
+    , fInBeamFrame { InBeamFrame }
+    , fOnBeamTime  { onBeamTime }
   {
-    for (unsigned int i = 0; i < PEperOpDet.size(); ++i)
-      fPEperOpDet.push_back(PEperOpDet[i]);
-    fFrame       = frame;
-    fAbsTime     = abstime;
-    fTimeWidth   = timewidth;
-    fTime        = time;
-    fYCenter     = yCenter;
-    fYWidth      = yWidth;
-    fZCenter     = zCenter;
-    fZWidth      = zWidth;
-    fWireWidths  = WireWidths;
-    fWireCenters = WireCenters;
-    fInBeamFrame = InBeamFrame;
-    fFastToTotal = FastToTotal;
-    fOnBeamTime  = onBeamTime;
   }
 
   //----------------------------------------------------------------------
@@ -55,10 +48,7 @@ namespace recob{
   //----------------------------------------------------------------------
   double OpFlash::TotalPE() const
   {
-    double theTotalPE=0;
-    for(size_t i=0; i!=fPEperOpDet.size(); ++i)
-      theTotalPE+=fPEperOpDet.at(i);
-    return theTotalPE;
+    return std::accumulate(fPEperOpDet.begin(), fPEperOpDet.end(), 0.0);
   }
 
 

--- a/lardataobj/RecoBase/OpFlash.h
+++ b/lardataobj/RecoBase/OpFlash.h
@@ -17,24 +17,24 @@ namespace recob {
   // has a certain number of PE; each subevent has a time associated with it
   class OpFlash {
     public:
-      OpFlash(); // Default constructor
+      OpFlash() = default;
 
 private:
 
-      double                fTime;         // Time relative to trigger
-      double                fTimeWidth;    // Width of the flash in time
-      double                fAbsTime;      // Time by PMT readout clock
-      unsigned int          fFrame;        // Frame number
-      std::vector< double > fPEperOpDet;   // Number of PE on each PMT
-      std::vector< double > fWireCenters;  // Geometric center in each view
-      std::vector< double > fWireWidths;   // Geometric width in each view
-      double                fYCenter;      // Geometric center in y
-      double                fYWidth;       // Geometric width in y
-      double                fZCenter;      // Geometric center in z
-      double                fZWidth;       // Geometric width in z
-      double                fFastToTotal;  // Fast to total light ratio
-      bool                  fInBeamFrame;  // Is this in the beam frame?
-      int                   fOnBeamTime;   // Is this in time with beam?
+      double                fTime { 0.0 }; ///< Time on @ref DetectorClocksHardwareTrigger "trigger time scale" [us]
+      double                fTimeWidth;    ///< Width of the flash in time [us]
+      double                fAbsTime;      ///< Time by PMT readout clock
+      unsigned int          fFrame;        ///< Frame number
+      std::vector< double > fPEperOpDet;   ///< Number of PE on each PMT
+      std::vector< double > fWireCenters;  ///< Geometric center in each view
+      std::vector< double > fWireWidths;   ///< Geometric width in each view
+      double                fYCenter;      ///< Geometric center in y [cm]
+      double                fYWidth;       ///< Geometric width in y [cm]
+      double                fZCenter;      ///< Geometric center in z [cm]
+      double                fZWidth;       ///< Geometric width in z [cm]
+      double                fFastToTotal;  ///< Fast to total light ratio
+      bool                  fInBeamFrame;  ///< Is this in the beam frame?
+      int                   fOnBeamTime;   ///< Is this in time with beam?
 
 
 
@@ -66,10 +66,8 @@ private:
       bool                  InBeamFrame()       const;
       int                   OnBeamTime()        const;
 
-      std::vector<double>   WireCenters()       const;
-      std::vector<double>   WireWidths()        const;
-
-      friend bool           operator <  (const OpFlash & a, const OpFlash & b);
+      std::vector<double> const& WireCenters()  const;
+      std::vector<double> const& WireWidths()   const;
 
       double                TotalPE()           const;
       double                FastToTotal()       const;
@@ -91,14 +89,15 @@ inline double recob::OpFlash::YWidth()            const { return fYWidth;      }
 inline double recob::OpFlash::ZCenter()           const { return fZCenter;     }
 inline double recob::OpFlash::ZWidth()            const { return fZWidth;      }
 inline double recob::OpFlash::FastToTotal()            const { return fFastToTotal;      }
-inline std::vector<double> recob::OpFlash::WireCenters()            const { return fWireCenters;      }
-inline std::vector<double> recob::OpFlash::WireWidths()             const { return fWireWidths;      }
+inline std::vector<double> const& recob::OpFlash::WireCenters() const { return fWireCenters;      }
+inline std::vector<double> const& recob::OpFlash::WireWidths() const { return fWireWidths;      }
 inline bool  recob::OpFlash::InBeamFrame()          const { return fInBeamFrame;     }
 inline int  recob::OpFlash::OnBeamTime()          const { return fOnBeamTime;     }
 
 namespace recob{
   struct OpFlashSortByTime {
-    bool operator() (recob::OpFlash i, recob::OpFlash j){ return i.Time() < j.Time(); }
+    bool operator() (recob::OpFlash const& i, recob::OpFlash const& j) const
+      { return i.Time() < j.Time(); }
   };
 }
 

--- a/lardataobj/RecoBase/OpFlash.h
+++ b/lardataobj/RecoBase/OpFlash.h
@@ -10,6 +10,8 @@
 #define OPFLASH_H
 
 #include <vector>
+#include <limits> // std::numeric_limits<>
+
 
 namespace recob {
 
@@ -17,6 +19,10 @@ namespace recob {
   // has a certain number of PE; each subevent has a time associated with it
   class OpFlash {
     public:
+      
+      /// Special value used for absence of center location information.
+      static constexpr double NoCenter = std::numeric_limits<double>::max();
+      
       OpFlash() = default;
 
 private:
@@ -28,6 +34,8 @@ private:
       std::vector< double > fPEperOpDet;   ///< Number of PE on each PMT
       std::vector< double > fWireCenters;  ///< Geometric center in each view
       std::vector< double > fWireWidths;   ///< Geometric width in each view
+      double                fXCenter { NoCenter }; ///< Estimated center in x [cm]
+      double                fXWidth { NoCenter }; ///< Estimated width in x [cm]
       double                fYCenter;      ///< Geometric center in y [cm]
       double                fYWidth;       ///< Geometric width in y [cm]
       double                fZCenter;      ///< Geometric center in z [cm]
@@ -40,6 +48,17 @@ private:
 
 
   public:
+      /// Constructor: all data members directly initialized.
+      OpFlash(double time, double timewidth, double abstime, unsigned int frame,
+	      std::vector< double > PEperOpDet,
+	      bool InBeamFrame, int OnBeamTime, double FastToTotal,
+	      double xCenter, double xWidth,
+	      double yCenter, double yWidth,
+	      double zCenter, double zWidth,
+	      std::vector<double> WireCenters = std::vector<double>(0),
+	      std::vector<double> WireWidths  = std::vector<double>(0));
+
+      /// Constructor: all data members directly initialized except x coordinate.
       OpFlash(double time, double timewidth, double abstime, unsigned int frame,
 	      std::vector< double > PEperOpDet,
 	      bool InBeamFrame=0, int OnBeamTime=0, double FastToTotal=1,
@@ -58,6 +77,12 @@ private:
       /// Returns a vector with a number of photoelectrons per channel.
       std::vector<double> const& PEs()          const;
 
+      /// Returns whether the estimated center on _x_ direction is available.
+      bool hasXCenter() const;
+      
+      /// Returns the estimated center on _x_ direction (@see `hasXCenter()`).
+      double                XCenter()           const;
+      double                XWidth()            const;
       double                YCenter()           const;
       double                YWidth()            const;
       double                ZCenter()           const;
@@ -84,6 +109,9 @@ inline double recob::OpFlash::AbsTime()           const { return fAbsTime;     }
 inline unsigned int recob::OpFlash::Frame()       const { return fFrame;       }
 inline double recob::OpFlash::PE(unsigned int i)  const { return fPEperOpDet[i]; }
 inline std::vector<double> const& recob::OpFlash::PEs() const { return fPEperOpDet; }
+inline bool recob::OpFlash::hasXCenter()          const { return fXCenter != NoCenter; }
+inline double recob::OpFlash::XCenter()           const { return fXCenter;     }
+inline double recob::OpFlash::XWidth()            const { return fXWidth;      }
 inline double recob::OpFlash::YCenter()           const { return fYCenter;     }
 inline double recob::OpFlash::YWidth()            const { return fYWidth;      }
 inline double recob::OpFlash::ZCenter()           const { return fZCenter;     }

--- a/lardataobj/RecoBase/classes_def.xml
+++ b/lardataobj/RecoBase/classes_def.xml
@@ -114,7 +114,8 @@
   <class name="recob::OpHit" ClassVersion="14">
     <version ClassVersion="14" checksum="3730974187"/>
   </class>
-  <class name="recob::OpFlash" ClassVersion="18">
+  <class name="recob::OpFlash" ClassVersion="19">
+    <version ClassVersion="19" checksum="4173863904"/>
     <version ClassVersion="18" checksum="507533507"/>
     <version ClassVersion="17" checksum="1882235791"/>
   </class>


### PR DESCRIPTION
The _x_ coordinate of a light flash can be inferred in detectors with a (semi)transparent cathode in the middle by properly weighting the amount of light at the two sides, and in the ones with a opaque but reflective cathode (SBND) by comparing the timing of reflected and direct light.

For backward compatibility, the new coordinate and width are assigned a "magic" value by default; `hasXCenter()` checks it. A new constructor can assign the additional coordinate and width. It should not collide with the existing ones.

The data product is extended, and ROOT schema evolution is expected to be able to handle the serialisation as needed.

Some questions are left for the review.

* Whether the strategy of construction is the most proper: I have _added_ a new constructor (needed for initializing the new data members) and the old one is still available and supposedly not colliding. This allows the old code to build and work without any change. An alternative approach is to require changes in the user code to assign placeholder information (`recob::OpFlash::NoCenter`) to the new data members, simplifying the class.
* I have deliberately added the constructor parameters for the new data members where they make the most sense to me, rather than at the end of the argument list, where it would be easier to handle them from the point of view of code. While I believe having a meaningful position is more important than having them in a place convenient for the update, that one remains an alternative possibility.
* Whether we should pay the inclusion of a LArSoft header to provide an interface returning a 3D vector as the location (currently, only standard C++ headers are required); this pull request does _not_ include such feature

As it is now, the change is expected to be **not breaking**.
I await for the integration tests to highlight any issue.

_Suggested reviewers_: @aihimmel , @ikatza.