### PR TITLE
Added dictionaries for vectors of art pointers to reconstructed objects

### DIFF
--- a/lardataobj/RecoBase/TrackingDicts/classes_def.xml
+++ b/lardataobj/RecoBase/TrackingDicts/classes_def.xml
@@ -162,6 +162,9 @@
   <class name="std::vector<recob::TrackTrajectory>"/>
   <class name="art::Wrapper<std::vector<recob::TrackTrajectory>>"/>
 
+  <class name="std::vector<art::Ptr<recob::TrackTrajectory>>"/>
+  <class name="art::Wrapper<std::vector<art::Ptr<recob::TrackTrajectory>>>"/>
+      
     <!-- associations and wrappers -->
       <!-- hits -->
   <class name="art::Assns<recob::Hit, recob::TrackTrajectory, void>"/>
@@ -312,6 +315,9 @@
   <class name="std::vector<recob::Track>"/>
   <class name="art::Wrapper<std::vector<recob::Track>>"/>
 
+  <class name="std::vector<art::Ptr<recob::Track>>"/>
+  <class name="art::Wrapper<std::vector<art::Ptr<recob::Track>>>"/>
+      
   <class name="art::PtrVector<recob::Track>"/>
   <class name="std::vector<art::PtrVector<recob::Track>>"/>
   <class name="art::Wrapper<std::vector<art::PtrVector<recob::Track>>>"/>

--- a/lardataobj/RecoBase/classes_def.xml
+++ b/lardataobj/RecoBase/classes_def.xml
@@ -163,7 +163,12 @@
   <class name="art::PtrVector<recob::OpFlash>"/>
   <class name="art::PtrVector<recob::TrackFitHitInfo>"/>
   <class name="art::PtrVector<recob::MCSFitResult>"/>
+  <class name="std::vector<art::Ptr<recob::Hit>>"/>
   <class name="std::vector<art::Ptr<recob::Cluster>>"/>
+  <class name="std::vector<art::Ptr<recob::Shower>>"/>
+  <class name="std::vector<art::Ptr<recob::PFParticle>>"/>
+  <class name="std::vector<art::Ptr<recob::Vertex>>"/>
+  <class name="std::vector<art::Ptr<recob::OpFlash>>"/>
   <class name="std::vector< art::PtrVector<recob::Cluster>>"/>
   <class name="std::vector< art::PtrVector<recob::TrackFitHitInfo>>"/>
 
@@ -206,7 +211,12 @@
   <class name="art::Wrapper< std::vector< recob::OpFlash>>"/>
   <class name="art::Wrapper< std::vector< recob::MCSFitResult>>"/>
   <class name="art::Wrapper< std::vector< art::PtrVector<recob::Cluster>>>"/>
+  <class name="art::Wrapper< std::vector< art::Ptr<recob::Hit>>>"/>
   <class name="art::Wrapper< std::vector< art::Ptr<recob::Cluster>>>"/>
+  <class name="art::Wrapper< std::vector< art::Ptr<recob::Shower>>>"/>
+  <class name="art::Wrapper< std::vector< art::Ptr<recob::PFParticle>>>"/>
+  <class name="art::Wrapper< std::vector< art::Ptr<recob::Vertex>>>"/>
+  <class name="art::Wrapper< std::vector< art::Ptr<recob::OpFlash>>>"/>
   <class name="art::Wrapper< std::vector< std::vector<recob::TrackFitHitInfo>>>"/>
 
   <!-- io rules for types in this file -->


### PR DESCRIPTION
ICARUS is a detector with two cryostats, and it's not unusual that reconstruction of the different cryostats (or TPC) is performed by different modules. But it may be useful afterwards to have selection of objects that cross those boundaries and pick from several collections (and several data products).
For that, a list of `art::Ptr` to the reconstructed objects can be saved.

Currently, dictionaries are available for many data products of type `art::PtrVector<recob::Xxxx>`, but `art::PtrVector` can't host pointers from different collections. This pull request adds ROOT dictionaries for the objects that are more likely to be needed in a selection (particles, tracks, showers, vertices...).