### PR TITLE
Added missing header to BeamGateInfo.h

### DIFF
--- a/lardataobj/Simulation/BeamGateInfo.h
+++ b/lardataobj/Simulation/BeamGateInfo.h
@@ -8,6 +8,8 @@
 
 #include "lardataobj/Simulation/BeamTypes.h"
 
+#include <functional> // std::less
+
 namespace sim {
 
   class BeamGateInfo
@@ -22,8 +24,6 @@ namespace sim {
       , fm_width(width)
       , fm_beam_type(type)
     {}
-
-    ~BeamGateInfo() {};
 
     // No "setters" for beam-gate start or width; you have to assign
     // them when you create a BeamGateInfo object.


### PR DESCRIPTION
It turns out `std::less` was not defined.
Also removing an unnecessary destructor, just because.

This is Yet Another @PetrilloAtWork's GitHub-Only Commit. I.e., not even tried to compile, relying on C.I. :crossed_fingers: 