### PR TITLE
Migrate to Cetmodules 3.12.00 and modern CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,16 +22,18 @@ cet_set_compiler_flags(DIAGS CAUTIOUS
 
 cet_report_compiler_flags(REPORT_THRESHOLD VERBOSE)
 
-find_package(cetlib_except REQUIRED EXPORT)
-find_package(cetlib REQUIRED EXPORT)
-find_package(messagefacility REQUIRED EXPORT)
-find_package(canvas REQUIRED EXPORT)
-find_package(canvas_root_io REQUIRED)
 find_package(nusimdata REQUIRED EXPORT)
-find_package(Boost REQUIRED)
-find_package(ROOT COMPONENTS Core Physics GenVector Matrix REQUIRED EXPORT)
-find_package( larcoreobj REQUIRED EXPORT)
-find_package( larcorealg REQUIRED EXPORT)
+
+find_package(canvas_root_io REQUIRED EXPORT)
+find_package(canvas REQUIRED EXPORT)
+find_package(messagefacility REQUIRED EXPORT)
+find_package(cetlib_except REQUIRED EXPORT)
+
+find_package(Boost COMPONENTS HEADERS REQUIRED EXPORT)
+find_package(ROOT COMPONENTS Core GenVector MathCore Matrix Physics REQUIRED EXPORT)
+
+find_package(larcoreobj REQUIRED EXPORT)
+find_package(larcorealg REQUIRED EXPORT)
 
 include(BuildDictionary)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,120 @@
+{
+   "configurePresets" : [
+      {
+         "cacheVariables" : {
+            "CMAKE_BUILD_TYPE" : {
+               "type" : "STRING",
+               "value" : "RelWithDebInfo"
+            },
+            "CMAKE_CXX_EXTENSIONS" : {
+               "type" : "BOOL",
+               "value" : "OFF"
+            },
+            "CMAKE_CXX_STANDARD_REQUIRED" : {
+               "type" : "BOOL",
+               "value" : "ON"
+            },
+            "lardataobj_ADD_NOARCH_DIRS_INIT" : {
+               "type" : "INTERNAL",
+               "value" : "FHICL_DIR"
+            },
+            "lardataobj_FHICL_DIR_INIT" : {
+               "type" : "STRING",
+               "value" : "job"
+            }
+         },
+         "description" : "Configuration settings translated from ups/product_deps",
+         "displayName" : "Configuration from product_deps",
+         "hidden" : true,
+         "name" : "from_product_deps"
+      },
+      {
+         "cacheVariables" : {
+            "CMAKE_CXX_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER}"
+            },
+            "CMAKE_CXX_STANDARD" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_STANDARD}"
+            },
+            "CMAKE_C_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER}"
+            },
+            "CMAKE_Fortran_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER}"
+            },
+            "UPS_CXX_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER_ID}"
+            },
+            "UPS_CXX_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER_VERSION}"
+            },
+            "UPS_C_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER_ID}"
+            },
+            "UPS_C_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER_VERSION}"
+            },
+            "UPS_Fortran_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER_ID}"
+            },
+            "UPS_Fortran_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER_VERSION}"
+            },
+            "WANT_UPS" : {
+               "type" : "BOOL",
+               "value" : true
+            },
+            "lardataobj_EXEC_PREFIX_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_FQ_DIR}"
+            },
+            "lardataobj_UPS_BUILD_ONLY_DEPENDENCIES_INIT" : {
+               "type" : "STRING",
+               "value" : "cetmodules"
+            },
+            "lardataobj_UPS_PRODUCT_FLAVOR_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_FLAVOR}"
+            },
+            "lardataobj_UPS_PRODUCT_NAME_INIT" : {
+               "type" : "STRING",
+               "value" : "lardataobj"
+            },
+            "lardataobj_UPS_QUALIFIER_STRING_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_QUALSPEC}"
+            }
+         },
+         "description" : "Extra configuration for UPS package generation",
+         "displayName" : "UPS extra configuration",
+         "hidden" : true,
+         "name" : "extra_for_UPS"
+      },
+      {
+         "description" : "Default configuration including settings from ups/product_deps",
+         "displayName" : "Default configuration",
+         "inherits" : "from_product_deps",
+         "name" : "default"
+      },
+      {
+         "description" : "Default configuration for UPS package generation",
+         "displayName" : "Default configuration for UPS",
+         "inherits" : [
+            "default",
+            "extra_for_UPS"
+         ],
+         "name" : "for_UPS"
+      }
+   ],
+   "version" : 3
+}

--- a/lardataobj/AnalysisBase/CMakeLists.txt
+++ b/lardataobj/AnalysisBase/CMakeLists.txt
@@ -1,21 +1,30 @@
-cet_make_library(
-      SOURCE
-        Calorimetry.cxx
-        CosmicTag.cxx
-        FlashMatch.cxx
-        MVAOutput.cxx
-        ParticleID.cxx
-        T0.cxx
-      LIBRARIES
-        canvas::canvas
-        cetlib_except::cetlib_except
-        ROOT::Core
-        PUBLIC
-           larcoreobj::headers
-           larcorealg::geoVectorUtils
+cet_make_library(LIBRARY_NAME RDTimeStamp INTERFACE
+  SOURCE RDTimeStamp.h
+  LIBRARIES INTERFACE
+  ROOT::Core
 )
 
-build_dictionary(DICTIONARY_LIBRARIES lardataobj_AnalysisBase nusimdata::SimulationBase)
+cet_make_library(SOURCE
+  Calorimetry.cxx
+  CosmicTag.cxx
+  FlashMatch.cxx
+  MVAOutput.cxx
+  ParticleID.cxx
+  T0.cxx
+  LIBRARIES
+  PUBLIC
+  lardataobj::RawData
+  lardataobj::RecoBase
+  larcoreobj::SimpleTypesAndConstants
+  nusimdata::SimulationBase
+  canvas::canvas
+  cetlib_except::cetlib_except
+)
+
+build_dictionary(DICTIONARY_LIBRARIES
+  lardataobj::AnalysisBase
+  canvas::canvas
+)
 
 install_headers()
 install_source()

--- a/lardataobj/CMakeLists.txt
+++ b/lardataobj/CMakeLists.txt
@@ -1,7 +1,9 @@
-add_subdirectory(AnalysisBase)
-add_subdirectory(OpticalDetectorData)
+cet_make_library(HEADERS_TARGET_ONLY)
+
 add_subdirectory(RawData)
 add_subdirectory(RecoBase)
+add_subdirectory(AnalysisBase)
+add_subdirectory(OpticalDetectorData)
 add_subdirectory(MCBase)
 add_subdirectory(Utilities)
 add_subdirectory(Simulation)

--- a/lardataobj/MCBase/CMakeLists.txt
+++ b/lardataobj/MCBase/CMakeLists.txt
@@ -1,19 +1,21 @@
-cet_make_library(
-         SOURCE
-           MCBaseException.cxx
-           MCHitCollection.cxx
-           MCHit.cxx
-           MCShower.cxx
-           MCTrack.cxx
-           MCWireCollection.cxx
-           MCWire.cxx
-         LIBRARIES
-           nusimdata::SimulationBase
-           ROOT::Core
-           ROOT::Physics
-         )
+cet_make_library(SOURCE
+  MCBaseException.cxx
+  MCHitCollection.cxx
+  MCHit.cxx
+  MCShower.cxx
+  MCStep.h
+  MCTrack.cxx
+  MCWireCollection.cxx
+  MCWire.cxx
+  LIBRARIES
+  PUBLIC
+  nusimdata::SimulationBase
+  ROOT::Physics
+)
 
-build_dictionary(DICTIONARY_LIBRARIES lardataobj_MCBase canvas::canvas)
+build_dictionary(DICTIONARY_LIBRARIES
+  lardataobj::MCBase canvas::canvas
+)
 
 install_headers()
 install_source()

--- a/lardataobj/OpticalDetectorData/CMakeLists.txt
+++ b/lardataobj/OpticalDetectorData/CMakeLists.txt
@@ -1,6 +1,6 @@
-cet_make_library(SOURCE OpticalDetectorData.cxx)
-
-build_dictionary(DICTIONARY_LIBRARIES lardataobj_OpticalDetectorData canvas::canvas)
+build_dictionary(DICTIONARY_LIBRARIES
+  canvas::canvas
+)
 
 install_headers()
 install_source()

--- a/lardataobj/RawData/CMakeLists.txt
+++ b/lardataobj/RawData/CMakeLists.txt
@@ -1,21 +1,27 @@
-cet_make_library(
-         SOURCE
-           AuxDetDigit.cxx
-           BeamInfo.cxx
-           DAQHeader.cxx
-           ExternalTrigger.cxx
-           OpDetPulse.cxx
-           raw.cxx
-           RawDigit.cxx
-           TriggerData.cxx
-         LIBRARIES
-           larcoreobj::SummaryData
-           canvas::canvas
-           messagefacility::MF_MessageLogger
-           cetlib_except::cetlib_except
-           ROOT::Core)
+cet_make_library(SOURCE
+  AuxDetDigit.cxx
+  BeamInfo.cxx
+  DAQHeader.cxx
+  ExternalTrigger.cxx
+  OpDetPulse.cxx
+  raw.cxx
+  RawDigit.cxx
+  RDTimeStamp.h
+  TriggerData.cxx
+  LIBRARIES
+  PUBLIC
+  Boost::headers
+  ROOT::Core
+  larcoreobj::headers
+  PRIVATE
+  messagefacility::MF_MessageLogger
+  cetlib_except::cetlib_except
+)
 
-build_dictionary(DICTIONARY_LIBRARIES lardataobj_RawData)
+build_dictionary(DICTIONARY_LIBRARIES
+  lardataobj::RawData
+  canvas::canvas
+)
 
 install_headers()
 install_source()

--- a/lardataobj/RecoBase/AssnsDicts/CMakeLists.txt
+++ b/lardataobj/RecoBase/AssnsDicts/CMakeLists.txt
@@ -1,4 +1,7 @@
-build_dictionary(DICTIONARY_LIBRARIES lardataobj_RecoBase)
+build_dictionary(DICTIONARY_LIBRARIES
+  lardataobj::RecoBase
+  canvas::canvas
+)
 
 install_headers()
 install_source()

--- a/lardataobj/RecoBase/CMakeLists.txt
+++ b/lardataobj/RecoBase/CMakeLists.txt
@@ -1,42 +1,62 @@
-cet_make_library(
-  SOURCE
-    Cluster.cxx
-    Edge.cxx
-    EndPoint2D.cxx
-    Event.cxx
-    Hit.cxx
-    OpFlash.cxx
-    OpHit.cxx
-    PCAxis.cxx
-    PFParticle.cxx
-    PFParticleMetadata.cxx
-    Seed.cxx
-    Shower.cxx
-    Slice.cxx
-    SpacePoint.cxx
-    Track.cxx
-    TrackingPlane.cxx
-    TrackTrajectory.cxx
-    Trajectory.cxx
-    TrajectoryPointFlags.cxx
-    Vertex.cxx
-    Wire.cxx
-  LIBRARIES
-                   canvas::canvas
-                   messagefacility::MF_MessageLogger
-                   cetlib_except::cetlib_except
-                   ROOT::Physics
-                   ROOT::Matrix
-                   ROOT::GenVector
-  PUBLIC
-     lardataobj::RawData
-     larcorealg::geoVectorUtils
+cet_make_library(LIBRARY_NAME TrackingTypes INTERFACE
+  SOURCE TrackingTypes.h
+  LIBRARIES INTERFACE
+  larcorealg::Geometry
+  larcorealg::geo_vectors_utils
+  ROOT::GenVector
+  ROOT::Matrix
+  ROOT::Physics
 )
 
-build_dictionary(DICTIONARY_LIBRARIES lardataobj_RecoBase)
+cet_make_library(LIBRARY_NAME TrackFitHitInfo INTERFACE
+  SOURCE TrackFitHitInfo.h
+  LIBRARIES INTERFACE
+  lardataobj::TrackingTypes
+  larcoreobj::SimpleTypesAndConstants
+)
+
+cet_make_library(SOURCE
+  Cluster.cxx
+  Edge.cxx
+  EndPoint2D.cxx
+  Event.cxx
+  Hit.cxx
+  OpFlash.cxx
+  OpHit.cxx
+  PCAxis.cxx
+  PFParticle.cxx
+  PFParticleMetadata.cxx
+  Seed.cxx
+  Shower.cxx
+  Slice.cxx
+  SpacePoint.cxx
+  Track.cxx
+  TrackingPlane.cxx
+  TrackTrajectory.cxx
+  Trajectory.cxx
+  TrajectoryPointFlags.cxx
+  Vertex.cxx
+  Wire.cxx
+  LIBRARIES
+  PUBLIC
+  lardataobj::TrackingTypes
+  larcoreobj::SimpleTypesAndConstants
+  larcoreobj::geo_vectors
+  ROOT::Core
+  ROOT::Physics
+  PRIVATE
+  messagefacility::MF_MessageLogger
+)
+
+build_dictionary(DICTIONARY_LIBRARIES
+  lardataobj::RecoBase
+  lardataobj::TrackFitHitInfo
+  lardataobj::TrackingTypes
+  canvas::canvas
+)
 
 add_subdirectory(AssnsDicts)
 add_subdirectory(TrackingDicts)
 
-install_headers(EXTRAS TrajectoryPointFlags.tcc TrackTrajectory.tcc Trajectory.tcc)
+install_headers()
 install_source(EXTRAS RecoBase.dox)

--- a/lardataobj/RecoBase/TrackingDicts/CMakeLists.txt
+++ b/lardataobj/RecoBase/TrackingDicts/CMakeLists.txt
@@ -1,4 +1,7 @@
-build_dictionary(DICTIONARY_LIBRARIES lardataobj_RecoBase)
+build_dictionary(DICTIONARY_LIBRARIES
+  lardataobj::RecoBase
+  canvas::canvas
+)
 
 install_headers()
 install_source()

--- a/lardataobj/Simulation/CMakeLists.txt
+++ b/lardataobj/Simulation/CMakeLists.txt
@@ -1,22 +1,36 @@
-cet_make_library(
-         SOURCE
-           AuxDetSimChannel.cxx
-           OpDetBacktrackerRecord.cxx
-           SimChannel.cxx
-           SimPhotons.cxx
-           SupernovaTruth.cxx
-         LIBRARIES
-           canvas::canvas
-           messagefacility::MF_MessageLogger
-           ROOT::GenVector
-           ROOT::Core
-           ROOT::Physics
-           PUBLIC
-           nusimdata::SimulationBase
-           larcoreobj::headers
-         )
+cet_make_library(LIBRARY_NAME sim INTERFACE
+  SOURCE sim.h
+  LIBRARIES INTERFACE
+  ROOT::MathCore
+)
 
-build_dictionary(DICTIONARY_LIBRARIES lardataobj_Simulation)
+cet_make_library(LIBRARY_NAME GeneratedParticleInfo INTERFACE
+  SOURCE GeneratedParticleInfo.h
+  LIBRARIES INTERFACE
+  nusimdata::SimulationBase
+)
+
+cet_make_library(SOURCE
+  AuxDetSimChannel.cxx
+  SimDriftedElectronCluster.h
+  SimEnergyDeposit.h
+  OpDetBacktrackerRecord.cxx
+  SimChannel.cxx
+  SimPhotons.cxx
+  SupernovaTruth.cxx
+  LIBRARIES
+  PUBLIC
+  larcoreobj::geo_vectors
+  PRIVATE
+  lardataobj::sim
+  messagefacility::MF_MessageLogger
+)
+
+build_dictionary(DICTIONARY_LIBRARIES
+  lardataobj::Simulation
+  lardataobj::GeneratedParticleInfo
+  canvas::canvas
+)
 
 install_headers()
 install_source()

--- a/lardataobj/Simulation/sim.h
+++ b/lardataobj/Simulation/sim.h
@@ -3,13 +3,6 @@
 /// \brief Tools and modules for checking out the basics of the Monte Carlo
 ///
 /// \author brebel@fnal.gov
-///
-///
-/// Coding note: Never put `#include "sim.h"` in your code. It would
-/// force a dependency in your class on every other class in the
-/// Simulation directory; e.g., if I changed the MCTruth code, your
-/// code that generates Electrons would re-compile.  This class exists
-/// solely as a bookkeeping tool.
 
 #ifndef LARDATAOBJ_SIMULATION_SIM_H
 #define LARDATAOBJ_SIMULATION_SIM_H

--- a/lardataobj/Utilities/CMakeLists.txt
+++ b/lardataobj/Utilities/CMakeLists.txt
@@ -1,2 +1,2 @@
-install_headers(EXTRAS BitMask.tcc FlagSet.tcc)
+install_headers()
 install_source()

--- a/test/RawData/CMakeLists.txt
+++ b/test/RawData/CMakeLists.txt
@@ -1,12 +1,16 @@
 # test raw data compression
 cet_test(raw_test USE_BOOST_UNIT
-  LIBRARIES lardataobj_RawData
-  )
+  LIBRARIES PRIVATE
+  lardataobj::RawData
+  larcoreobj::headers
+)
 
 # test data products
 cet_test(RawDigit_test USE_BOOST_UNIT
-  LIBRARIES lardataobj_RawData
-  )
+  LIBRARIES PRIVATE
+  lardataobj::RawData
+  larcoreobj::headers
+)
 
 install_headers()
 install_source()

--- a/test/RecoBase/CMakeLists.txt
+++ b/test/RecoBase/CMakeLists.txt
@@ -1,42 +1,51 @@
 cet_test(Wire_test USE_BOOST_UNIT
-  LIBRARIES lardataobj_RecoBase
-  )
+  LIBRARIES PRIVATE
+  lardataobj::RecoBase
+  larcoreobj::SimpleTypesAndConstants
+)
 
 cet_test(Hit_test USE_BOOST_UNIT
-  LIBRARIES lardataobj_RecoBase
-  )
+  LIBRARIES PRIVATE
+  lardataobj::RecoBase
+  larcoreobj::SimpleTypesAndConstants
+)
 
 cet_test(Cluster_test USE_BOOST_UNIT
-  LIBRARIES lardataobj_RecoBase
-  )
+  LIBRARIES PRIVATE
+  lardataobj::RecoBase
+  larcoreobj::SimpleTypesAndConstants
+)
 
 cet_test(PointCharge_test USE_BOOST_UNIT
-  LIBRARIES lardataobj_RecoBase
-  )
+  LIBRARIES PRIVATE
+  lardataobj::RecoBase
+)
 
 cet_test(Edge_test USE_BOOST_UNIT
-  LIBRARIES lardataobj_RecoBase
-  )
+  LIBRARIES PRIVATE
+  lardataobj::RecoBase
+)
 
 cet_test(TrajectoryPointFlags_test USE_BOOST_UNIT
-  LIBRARIES lardataobj_RecoBase
-  )
+  LIBRARIES PRIVATE
+  lardataobj::RecoBase
+)
 
 cet_test(Trajectory_test USE_BOOST_UNIT
-  LIBRARIES
-    lardataobj_RecoBase
-    ROOT::GenVector
-    ROOT::Physics
-    ROOT::Matrix
-  )
+  LIBRARIES PRIVATE
+  lardataobj::RecoBase
+  larcoreobj::headers
+  ROOT::Matrix
+  ROOT::Physics
+)
 
 cet_test(TrackTrajectory_test USE_BOOST_UNIT
-  LIBRARIES
-    lardataobj_RecoBase
-    ROOT::GenVector
-    ROOT::Physics
-    ROOT::Matrix
-  )
+  LIBRARIES PRIVATE
+  lardataobj::RecoBase
+  larcoreobj::headers
+  ROOT::Matrix
+  ROOT::Physics
+)
 
 install_headers()
 install_source()

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -250,7 +250,7 @@ product		version		qual	flags		<table_format=2>
 larcorealg	v09_06_02	-
 larcoreobj	v09_05_01	-
 nusimdata	v1_25_02	-
-cetmodules	v3_09_03	-	only_for_build
+cetmodules	v3_12_00	-	only_for_build
 end_product_list
 ####################################
 


### PR DESCRIPTION
- Cetmodules -> 3.12.00
- Improve CMake use and tighten dependencies
- Presets generated by Cetmodules 3.12.00
