### PR TITLE
fixed recob::Hit comparison operator based on StartTick with PeakTime

### DIFF
--- a/lardataobj/RecoBase/Hit.cxx
+++ b/lardataobj/RecoBase/Hit.cxx
@@ -115,8 +115,8 @@ namespace recob {
       return a.Channel() < b.Channel();
     if (a.View() != b.View())
       return a.View() < b.View();
-    if (a.StartTick() != b.StartTick())
-      return a.StartTick() < b.StartTick();
+    if (a.PeakTime() != b.PeakTime())
+      return a.PeakTime() < b.PeakTime();
 
     return false; //They are equal
   } // operator< (Hit, Hit)


### PR DESCRIPTION
The current implementation of the "< operator" in recob::Hits resolves hits with the same channel and view by comparing their StartTime.  Unfortunately this fails to resolve the ambiguities since StartTime is not unique and two different hits can have the same StartTime.  One should compare Hits based on PeakTime instead since this is unique for each hit.  This PR replaces the comparison based on StarTime with one based on PeakTime.