### PR TITLE
Add sim::SimEnergyDepositLite and sim::MCMiniPart

### DIFF
--- a/lardataobj/MCBase/MCMiniPart.h
+++ b/lardataobj/MCBase/MCMiniPart.h
@@ -37,18 +37,7 @@ namespace sim
 
   public:
 
-    /// Default constructor
-    MCMiniPart() {Reset();}
-
-    /// Default destructor
-    //virtual ~MCMiniPart() = default;
-
-    void Reset() { ResetData(); }
-
-    MCMiniPart(MCMiniPart const &) = default; // copy constructor
-    MCMiniPart& operator=( const MCMiniPart &) = default;
-    MCMiniPart(MCMiniPart&&) = default;
-    MCMiniPart& operator= (MCMiniPart&&) = default;
+    MCMiniPart(){};
 
     void ScaleStartMom(double factor) { _start_mom *= factor; }
     void ScaleEndMom(double factor)  { _end_mom *= factor; }
@@ -90,7 +79,6 @@ namespace sim
     void Daughters(const std::vector<unsigned int>& d) { _daughters = d; }
     void Daughters(std::vector<unsigned int>&& d) { _daughters = std::move(d); }
 
-    /// Explicit conversion operator to simb::MCParticle
     operator simb::MCParticle() const {
       simb::MCParticle mcpart(_track_id,
                               _pdgcode,
@@ -103,9 +91,9 @@ namespace sim
       return mcpart;
     }
 
-    /// Explicit constructor from simb::MCParticle
     MCMiniPart(const simb::MCParticle& p) {
-      Reset();
+      _daughters.clear();
+      _det_path.clear();
       _track_id = (unsigned int) p.TrackId();
       _pdgcode  = p.PdgCode();
       _mother   = (unsigned int) p.Mother();
@@ -117,36 +105,18 @@ namespace sim
     }
 
   protected:
-    unsigned int   _track_id;
-    std::string    _process;
-    unsigned int   _mother;
-    unsigned int   _ancestor;
-    int            _pdgcode;
-    TLorentzVector _start_vtx;
-    TLorentzVector _start_mom; ///< Start momentum in MeV
-    TLorentzVector _end_vtx; ///< End momentum in MeV
-    TLorentzVector _end_mom;
+    unsigned int   _track_id{kINVALID_UINT};
+    std::string    _process{};
+    unsigned int   _mother{kINVALID_UINT};
+    unsigned int   _ancestor{kINVALID_UINT};
+    int            _pdgcode{kINVALID_INT};
+    TLorentzVector _start_vtx{TLorentzVector(kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE)};
+    TLorentzVector _start_mom{TLorentzVector(kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE)}; ///< Start momentum in MeV
+    TLorentzVector _end_vtx{TLorentzVector(kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE)};
+    TLorentzVector _end_mom{TLorentzVector(kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE)}; ///< End momentum in MeV
     std::vector<std::pair<TLorentzVector,TLorentzVector> > _det_path;
     std::vector<unsigned int> _daughters;
-    ::simb::Origin_t _origin;
-
-    void ResetData(){
-      _track_id = _mother = _ancestor = kINVALID_UINT;
-      _pdgcode  = kINVALID_INT;
-      _process  = "";
-      _origin   = ::simb::kUnknown;
-
-      TLorentzVector invalid(kINVALID_DOUBLE,
-           kINVALID_DOUBLE,
-           kINVALID_DOUBLE,
-           kINVALID_DOUBLE);
-      _start_vtx = invalid;
-      _start_mom = invalid;
-      _end_vtx = invalid;
-      _end_mom = invalid;
-      _daughters.clear();
-      _det_path.clear();
-    }
+    ::simb::Origin_t _origin{::simb::kUnknown};
   };
 } // namespace sim
 

--- a/lardataobj/MCBase/MCMiniPart.h
+++ b/lardataobj/MCBase/MCMiniPart.h
@@ -1,0 +1,118 @@
+/**
+ * \file MCMiniPart.h
+ *
+ * \ingroup MCBase
+ *
+ * \brief Class def header for MCMiniPart data container
+ *
+ * @author Temigo
+ */
+
+/** \addtogroup MCBase
+
+    @{*/
+#ifndef MCMINIPART_H
+#define MCMINIPART_H
+
+// LArSoft
+//#include "lardataobj/MCBase/MCStep.h"
+#include "lardataobj/MCBase/MCLimits.h" // kINVALID_X
+//#include "nusimdata/SimulationBase/MCParticle.h"
+#include "nusimdata/SimulationBase/MCTruth.h" // simb::Origin_t
+
+// ROOT libraries
+#include <TVector3.h>
+
+// STL
+//#include <set>
+#include <utility> // std::pair<>
+#include <vector>
+
+#include "TLorentzVector.h"
+
+namespace sim
+{
+
+  class MCMiniPart {
+
+  public:
+
+    /// Default constructor
+    MCMiniPart() {Reset();}
+
+    /// Default destructor
+    //virtual ~MCMiniPart() = default;
+
+    void Reset() { ResetData(); }
+
+    MCMiniPart(MCMiniPart const &) = default; // copy constructor
+    MCMiniPart& operator=( const MCMiniPart &) = default;
+    MCMiniPart(MCMiniPart&&) = default;
+    MCMiniPart& operator= (MCMiniPart&&) = default;
+
+
+    // Getters
+    simb::Origin_t Origin () const { return _origin; }
+    int            PdgCode() const { return _pdgcode; }
+    unsigned int   TrackID() const { return _track_id; }
+    const std::string&    Process() const { return _process; }
+    unsigned int   Mother()  const { return _mother; }
+    unsigned int   Ancestor() const { return _ancestor; }
+    TLorentzVector StartVtx() const { return _start_vtx; }
+    TLorentzVector StartMom() const { return _start_mom; }
+    TLorentzVector EndVtx()   const { return _end_vtx; }
+    TLorentzVector EndMom()   const { return _end_mom; }
+    std::vector<std::pair<TLorentzVector,TLorentzVector> > DetPath() const { return _det_path; }
+    std::vector<unsigned int> Daughters() const { return _daughters; }
+
+    // Setters
+    void Origin (simb::Origin_t o) { _origin = o; }
+    void PdgCode(int id)           { _pdgcode = id; }
+    void TrackID(unsigned int id)  { _track_id = id; }
+    void Process(const std::string &name) { _process = name; }
+    void Mother(unsigned int id)   { _mother = id; }
+    void Ancestor(unsigned int id) { _ancestor = id; }
+    void StartVtx(const TLorentzVector& vtx) { _start_vtx = vtx; }
+    void StartMom(const TLorentzVector& mom) { _start_mom = mom; }
+    void EndVtx(const TLorentzVector& vtx)   { _end_vtx = vtx; }
+    void EndMom(const TLorentzVector& mom)   { _end_mom = mom; }
+    void DetPath(const std::vector<std::pair<TLorentzVector,TLorentzVector> >& p) { _det_path = p; }
+    void DetPath(std::vector<std::pair<TLorentzVector,TLorentzVector> >&& p) { _det_path = std::move(p); }
+    void Daughters(const std::vector<unsigned int>& d) { _daughters = d; }
+    void Daughters(std::vector<unsigned int>&& d) { _daughters = std::move(d); }
+
+  protected:
+    unsigned int   _track_id;
+    std::string    _process;
+    unsigned int   _mother;
+    unsigned int   _ancestor;
+    int            _pdgcode;
+    TLorentzVector _start_vtx;
+    TLorentzVector _start_mom;
+    TLorentzVector _end_vtx;
+    TLorentzVector _end_mom;
+    std::vector<std::pair<TLorentzVector,TLorentzVector> > _det_path;
+    std::vector<unsigned int> _daughters;
+    ::simb::Origin_t _origin;
+
+    void ResetData(){
+      _track_id = _mother = _ancestor = kINVALID_UINT;
+      _pdgcode  = kINVALID_INT;
+      _process  = "";
+      _origin   = ::simb::kUnknown;
+
+      TLorentzVector invalid(kINVALID_DOUBLE,
+           kINVALID_DOUBLE,
+           kINVALID_DOUBLE,
+           kINVALID_DOUBLE);
+      _start_vtx = invalid;
+      _start_mom = invalid;
+      _end_vtx = invalid;
+      _end_mom = invalid;
+      _daughters.clear();
+      _det_path.clear();
+    }
+  };
+} // namespace sim
+
+#endif

--- a/lardataobj/MCBase/MCMiniPart.h
+++ b/lardataobj/MCBase/MCMiniPart.h
@@ -5,6 +5,12 @@
  *
  * \brief Class def header for MCMiniPart data container
  *
+ * It is the same information as MCParticleLite. The only difference
+ * is in the units of momentum/energy: MeV for MCMiniPart and GeV for
+ * MCParticleLite. This is to keep backwards compatibility for modules
+ * and experiments that might be assuming sim::MCMiniPart has units of
+ * MeV for momentum/energy.
+ *
  * @author Temigo
  */
 
@@ -15,25 +21,13 @@
 #define MCMINIPART_H
 
 // LArSoft
-//#include "lardataobj/MCBase/MCStep.h"
-#include "lardataobj/MCBase/MCLimits.h" // kINVALID_X
+#include "lardataobj/MCBase/MCParticleLite.h"
 #include "nusimdata/SimulationBase/MCParticle.h"
-#include "nusimdata/SimulationBase/MCTruth.h" // simb::Origin_t
-
-// ROOT libraries
-#include <TVector3.h>
-
-// STL
-//#include <set>
-#include <utility> // std::pair<>
-#include <vector>
-
-#include "TLorentzVector.h"
 
 namespace sim
 {
 
-  class MCMiniPart {
+  class MCMiniPart : public MCParticleLite {
 
   public:
 
@@ -41,45 +35,8 @@ namespace sim
 
     void ScaleStartMom(double factor) { _start_mom *= factor; }
     void ScaleEndMom(double factor)  { _end_mom *= factor; }
-    void AddDaughter(unsigned int d) {
-      if (!this->HasDaughter(d))
-        _daughters.push_back(d);
-    }
-    bool HasDaughter(unsigned int d) const {
-      return std::find(_daughters.begin(), _daughters.end(), d) != _daughters.end();
-    }
 
-    // Getters
-    const simb::Origin_t& Origin () const { return _origin; }
-    int            PdgCode() const { return _pdgcode; }
-    unsigned int   TrackID() const { return _track_id; }
-    const std::string&    Process() const { return _process; }
-    unsigned int   Mother()  const { return _mother; }
-    unsigned int   Ancestor() const { return _ancestor; }
-    const TLorentzVector& StartVtx() const { return _start_vtx; }
-    const TLorentzVector& StartMom() const { return _start_mom; }
-    const TLorentzVector& EndVtx()   const { return _end_vtx; }
-    const TLorentzVector& EndMom()   const { return _end_mom; }
-    const std::vector<std::pair<TLorentzVector,TLorentzVector> >& DetPath() const { return _det_path; }
-    const std::vector<unsigned int>& Daughters() const { return _daughters; }
-
-    // Setters
-    void Origin (simb::Origin_t o) { _origin = o; }
-    void PdgCode(int id)           { _pdgcode = id; }
-    void TrackID(unsigned int id)  { _track_id = id; }
-    void Process(const std::string &name) { _process = name; }
-    void Mother(unsigned int id)   { _mother = id; }
-    void Ancestor(unsigned int id) { _ancestor = id; }
-    void StartVtx(const TLorentzVector& vtx) { _start_vtx = vtx; }
-    void StartMom(const TLorentzVector& mom) { _start_mom = mom; }
-    void EndVtx(const TLorentzVector& vtx)   { _end_vtx = vtx; }
-    void EndMom(const TLorentzVector& mom)   { _end_mom = mom; }
-    void DetPath(const std::vector<std::pair<TLorentzVector,TLorentzVector> >& p) { _det_path = p; }
-    void DetPath(std::vector<std::pair<TLorentzVector,TLorentzVector> >&& p) { _det_path = std::move(p); }
-    void Daughters(const std::vector<unsigned int>& d) { _daughters = d; }
-    void Daughters(std::vector<unsigned int>&& d) { _daughters = std::move(d); }
-
-    operator simb::MCParticle() const {
+    operator simb::MCParticle() const override {
       simb::MCParticle mcpart(_track_id,
                               _pdgcode,
                               _process,
@@ -91,32 +48,16 @@ namespace sim
       return mcpart;
     }
 
-    MCMiniPart(const simb::MCParticle& p) {
-      _daughters.clear();
-      _det_path.clear();
-      _track_id = (unsigned int) p.TrackId();
-      _pdgcode  = p.PdgCode();
-      _mother   = (unsigned int) p.Mother();
-      _process  = p.Process();
-      _start_vtx = p.Position();
-      _start_mom = 1.e3 * p.Momentum(); // Change units to LArSoft (MeV, cm, us)
-      _end_vtx = p.EndPosition();
-      _end_mom = 1.e3 * p.EndMomentum(); // idem as above
+    MCMiniPart(const simb::MCParticle& p) : MCParticleLite(p) {
+      ScaleStartMom(1.e3); // Change units to (MeV, cm, us)
+      ScaleEndMom(1.e3); // idem as above
     }
 
-  protected:
-    unsigned int   _track_id{kINVALID_UINT};
-    std::string    _process{};
-    unsigned int   _mother{kINVALID_UINT};
-    unsigned int   _ancestor{kINVALID_UINT};
-    int            _pdgcode{kINVALID_INT};
-    TLorentzVector _start_vtx{TLorentzVector(kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE)};
-    TLorentzVector _start_mom{TLorentzVector(kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE)}; ///< Start momentum in MeV
-    TLorentzVector _end_vtx{TLorentzVector(kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE)};
-    TLorentzVector _end_mom{TLorentzVector(kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE)}; ///< End momentum in MeV
-    std::vector<std::pair<TLorentzVector,TLorentzVector> > _det_path;
-    std::vector<unsigned int> _daughters;
-    ::simb::Origin_t _origin{::simb::kUnknown};
+    MCMiniPart(const sim::MCParticleLite& p) : MCParticleLite(p) {
+      ScaleStartMom(1.e3); // Change units to (MeV, cm, us)
+      ScaleEndMom(1.e3); // idem as above
+    }
+
   };
 } // namespace sim
 

--- a/lardataobj/MCBase/MCMiniPart.h
+++ b/lardataobj/MCBase/MCMiniPart.h
@@ -50,20 +50,29 @@ namespace sim
     MCMiniPart(MCMiniPart&&) = default;
     MCMiniPart& operator= (MCMiniPart&&) = default;
 
+    void ScaleStartMom(double factor) { _start_mom *= factor; }
+    void ScaleEndMom(double factor)  { _end_mom *= factor; }
+    void AddDaughter(unsigned int d) {
+      if (!this->HasDaughter(d))
+        _daughters.push_back(d);
+    }
+    bool HasDaughter(unsigned int d) const {
+      return std::find(_daughters.begin(), _daughters.end(), d) != _daughters.end();
+    }
 
     // Getters
-    simb::Origin_t Origin () const { return _origin; }
+    const simb::Origin_t& Origin () const { return _origin; }
     int            PdgCode() const { return _pdgcode; }
     unsigned int   TrackID() const { return _track_id; }
     const std::string&    Process() const { return _process; }
     unsigned int   Mother()  const { return _mother; }
     unsigned int   Ancestor() const { return _ancestor; }
-    TLorentzVector StartVtx() const { return _start_vtx; }
-    TLorentzVector StartMom() const { return _start_mom; }
-    TLorentzVector EndVtx()   const { return _end_vtx; }
-    TLorentzVector EndMom()   const { return _end_mom; }
-    std::vector<std::pair<TLorentzVector,TLorentzVector> > DetPath() const { return _det_path; }
-    std::vector<unsigned int> Daughters() const { return _daughters; }
+    const TLorentzVector& StartVtx() const { return _start_vtx; }
+    const TLorentzVector& StartMom() const { return _start_mom; }
+    const TLorentzVector& EndVtx()   const { return _end_vtx; }
+    const TLorentzVector& EndMom()   const { return _end_mom; }
+    const std::vector<std::pair<TLorentzVector,TLorentzVector> >& DetPath() const { return _det_path; }
+    const std::vector<unsigned int>& Daughters() const { return _daughters; }
 
     // Setters
     void Origin (simb::Origin_t o) { _origin = o; }

--- a/lardataobj/MCBase/MCParticleLite.h
+++ b/lardataobj/MCBase/MCParticleLite.h
@@ -1,0 +1,121 @@
+/**
+ * \file MCParticleLite.h
+ *
+ * \ingroup MCBase
+ *
+ * \brief Class def header for MCParticleLite data container
+ *
+ * @author Temigo
+ */
+
+/** \addtogroup MCBase
+
+    @{*/
+#ifndef MCPARTICLELITE_H
+#define MCPARTICLELITE_H
+
+// LArSoft
+//#include "lardataobj/MCBase/MCStep.h"
+#include "lardataobj/MCBase/MCLimits.h" // kINVALID_X
+#include "nusimdata/SimulationBase/MCParticle.h"
+#include "nusimdata/SimulationBase/MCTruth.h" // simb::Origin_t
+
+// ROOT libraries
+#include <TVector3.h>
+
+// STL
+//#include <set>
+#include <utility> // std::pair<>
+#include <vector>
+
+#include "TLorentzVector.h"
+
+namespace sim
+{
+
+  class MCParticleLite {
+
+  public:
+
+    MCParticleLite(){};
+    virtual ~MCParticleLite(){};
+
+    void AddDaughter(unsigned int d) {
+      if (!this->HasDaughter(d))
+        _daughters.push_back(d);
+    }
+    bool HasDaughter(unsigned int d) const {
+      return std::find(_daughters.begin(), _daughters.end(), d) != _daughters.end();
+    }
+
+    // Getters
+    const simb::Origin_t& Origin () const { return _origin; }
+    int            PdgCode() const { return _pdgcode; }
+    unsigned int   TrackID() const { return _track_id; }
+    const std::string&    Process() const { return _process; }
+    unsigned int   Mother()  const { return _mother; }
+    unsigned int   Ancestor() const { return _ancestor; }
+    const TLorentzVector& StartVtx() const { return _start_vtx; }
+    const TLorentzVector& StartMom() const { return _start_mom; }
+    const TLorentzVector& EndVtx()   const { return _end_vtx; }
+    const TLorentzVector& EndMom()   const { return _end_mom; }
+    const std::vector<std::pair<TLorentzVector,TLorentzVector> >& DetPath() const { return _det_path; }
+    const std::vector<unsigned int>& Daughters() const { return _daughters; }
+
+    // Setters
+    void Origin (simb::Origin_t o) { _origin = o; }
+    void PdgCode(int id)           { _pdgcode = id; }
+    void TrackID(unsigned int id)  { _track_id = id; }
+    void Process(const std::string &name) { _process = name; }
+    void Mother(unsigned int id)   { _mother = id; }
+    void Ancestor(unsigned int id) { _ancestor = id; }
+    void StartVtx(const TLorentzVector& vtx) { _start_vtx = vtx; }
+    void StartMom(const TLorentzVector& mom) { _start_mom = mom; }
+    void EndVtx(const TLorentzVector& vtx)   { _end_vtx = vtx; }
+    void EndMom(const TLorentzVector& mom)   { _end_mom = mom; }
+    void DetPath(const std::vector<std::pair<TLorentzVector,TLorentzVector> >& p) { _det_path = p; }
+    void DetPath(std::vector<std::pair<TLorentzVector,TLorentzVector> >&& p) { _det_path = std::move(p); }
+    void Daughters(const std::vector<unsigned int>& d) { _daughters = d; }
+    void Daughters(std::vector<unsigned int>&& d) { _daughters = std::move(d); }
+
+    virtual operator simb::MCParticle() const {
+      simb::MCParticle mcpart(_track_id,
+                              _pdgcode,
+                              _process,
+                              _mother);
+      mcpart.AddTrajectoryPoint(_start_vtx, _start_mom);
+      mcpart.AddTrajectoryPoint(_end_vtx, _end_mom);
+      for (auto const & d : _daughters) mcpart.AddDaughter(d);
+      return mcpart;
+    }
+
+    MCParticleLite(const simb::MCParticle& p) {
+      _daughters.clear();
+      _det_path.clear();
+      _track_id = (unsigned int) p.TrackId();
+      _pdgcode  = p.PdgCode();
+      _mother   = (unsigned int) p.Mother();
+      _process  = p.Process();
+      _start_vtx = p.Position();
+      _start_mom = p.Momentum();
+      _end_vtx = p.EndPosition();
+      _end_mom = p.EndMomentum();
+    }
+
+  protected:
+    unsigned int   _track_id{kINVALID_UINT};
+    std::string    _process{};
+    unsigned int   _mother{kINVALID_UINT};
+    unsigned int   _ancestor{kINVALID_UINT};
+    int            _pdgcode{kINVALID_INT};
+    TLorentzVector _start_vtx{TLorentzVector(kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE)};
+    TLorentzVector _start_mom{TLorentzVector(kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE)}; ///< Start momentum in GeV
+    TLorentzVector _end_vtx{TLorentzVector(kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE)};
+    TLorentzVector _end_mom{TLorentzVector(kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE, kINVALID_DOUBLE)}; ///< End momentum in GeV
+    std::vector<std::pair<TLorentzVector,TLorentzVector> > _det_path;
+    std::vector<unsigned int> _daughters;
+    ::simb::Origin_t _origin{::simb::kUnknown};
+  };
+} // namespace sim
+
+#endif

--- a/lardataobj/MCBase/classes.h
+++ b/lardataobj/MCBase/classes.h
@@ -6,3 +6,4 @@
 #include "lardataobj/MCBase/MCHitCollection.h"
 #include "lardataobj/MCBase/MCShower.h"
 #include "lardataobj/MCBase/MCTrack.h"
+#include "lardataobj/MCBase/MCMiniPart.h"

--- a/lardataobj/MCBase/classes_def.xml
+++ b/lardataobj/MCBase/classes_def.xml
@@ -30,8 +30,12 @@
  <version ClassVersion="11" checksum="1998549158"/>
  <version ClassVersion="10" checksum="1862388136"/>
 </class>
-<class name="sim::MCMiniPart" ClassVersion="10" >
+<class name="sim::MCMiniPart" ClassVersion="11" >
+ <version ClassVersion="11" checksum="3396563188"/>
  <version ClassVersion="10" checksum="924559196"/>
+</class>
+<class name="sim::MCParticleLite" ClassVersion="10" >
+ <version ClassVersion="10" checksum="1468541834"/>
 </class>
 
 <class name="std::vector<sim::MCHit>"/>
@@ -58,6 +62,10 @@
 <class name="std::vector<sim::MCMiniPart>"/>
 <class name="art::Wrapper< std::vector<sim::MCMiniPart>>"/>
 <class name="art::Ptr<sim::MCMiniPart>" />
+
+<class name="std::vector<sim::MCParticleLite>"/>
+<class name="art::Wrapper< std::vector<sim::MCParticleLite>>"/>
+<class name="art::Ptr<sim::MCParticleLite>" />
 
 <ioread
   version="[10]"

--- a/lardataobj/MCBase/classes_def.xml
+++ b/lardataobj/MCBase/classes_def.xml
@@ -30,6 +30,9 @@
  <version ClassVersion="11" checksum="1998549158"/>
  <version ClassVersion="10" checksum="1862388136"/>
 </class>
+<class name="sim::MCMiniPart" ClassVersion="10" >
+ <version ClassVersion="10" checksum="924559196"/>
+</class>
 
 <class name="std::vector<sim::MCHit>"/>
 <class name="art::Wrapper< std::vector<sim::MCHit>>"/>
@@ -52,20 +55,23 @@
 <class name="std::vector<sim::MCTrack>"/>
 <class name="art::Wrapper< std::vector<sim::MCTrack>>"/>
 
+<class name="std::vector<sim::MCMiniPart>"/>
+<class name="art::Wrapper< std::vector<sim::MCMiniPart>>"/>
+<class name="art::Ptr<sim::MCMiniPart>" />
 
-<ioread 
-  version="[10]" 
-  sourceClass="sim::MCHit" 
-  source="std::vector<double> fPartVertex" 
-  targetClass="sim::MCHit" 
-  target="fPartVertex" 
+<ioread
+  version="[10]"
+  sourceClass="sim::MCHit"
+  source="std::vector<double> fPartVertex"
+  targetClass="sim::MCHit"
+  target="fPartVertex"
   include="vector;lardataobj/MCBase/MCHit.h">
   <![CDATA[
     fPartVertex[0] = (onfile.fPartVertex.size()> 0 ? onfile.fPartVertex[0] : 0.);
     fPartVertex[1] = (onfile.fPartVertex.size()> 1 ? onfile.fPartVertex[1] : 0.);
     fPartVertex[2] = (onfile.fPartVertex.size()> 2 ? onfile.fPartVertex[2] : 0.);
   ]]>
-</ioread> 
+</ioread>
 
 
 </lcgdict>

--- a/lardataobj/Simulation/SimEnergyDepositLite.h
+++ b/lardataobj/Simulation/SimEnergyDepositLite.h
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////
 /// \file  lardataobj/Simulation/SimEnergyDepositLite.h
 /// \brief contains information for a single step in the detector simulation
-///					(pared down in size to the essential information)
+///         (pared down in size to the essential information)
 /// \authors Laura Domine
 ////////////////////////////////////////////////////////////////////////
 #ifndef LARDATAOBJ_SIMULATION_SIMENERGYDEPOSITLITE_H
@@ -21,60 +21,54 @@ namespace sim
    * @brief Energy deposition in the active material (lite version).
    *
    * The detector simulation (presently LArG4, which invokes Geant4)
-	 * propagates particles through the detector in intervals of "steps".
-	 * These are usually stored in sim::SimEnergyDeposit objects. For
-	 * filesize concerns we pare it down to the essential information.
-	 */
-	class SimEnergyDepositLite
-	{
-	public:
+   * propagates particles through the detector in intervals of "steps".
+   * These are usually stored in sim::SimEnergyDeposit objects. For
+   * filesize concerns we pare it down to the essential information.
+   */
+  class SimEnergyDepositLite
+  {
+  public:
 
-		using Length_t = float;
-		using Point_t = geo::Point_t;
+    using Length_t = float;
+    using Point_t = geo::Point_t;
 
-		SimEnergyDepositLite(double e = 0.,
-												geo::Point_t middle = {0., 0., 0.},
-												double t = 0.,
-												int id = 0)
-											: edep(e)
-											, middlePos(middle)
-											, middleTime(t)
-											, trackID(id)
-		{}
+    SimEnergyDepositLite(double e = 0.,
+                        geo::Point_t middle = {0., 0., 0.},
+                        double t = 0.,
+                        int id = 0)
+                      : edep(e)
+                      , middlePos(middle)
+                      , middleTime(t)
+                      , trackID(id)
+    {}
 
-		double Energy() const { return edep; }
-		geo::Point_t Position() const { return { middlePos.X(), middlePos.Y(), middlePos.Z() }; }
-    geo::Point_t MidPoint() const { return Position();} ///< Just an alias for compatibility with SED
-		double Time() const { return middleTime; }
-		int TrackID() const { return trackID; }
-		void setTrackID(int id) { trackID = id; }
-		void setEnergy(double e) { edep = e; }
-    void setTime(double t) { middleTime = t; }
+    double Energy() const { return edep; }
+    geo::Point_t const& Position() const noexcept { return middlePos; }
+    geo::Point_t const& MidPoint() const noexcept { return Position();} ///< Just an alias for compatibility with SED
+    double Time() const { return middleTime; }
+    int TrackID() const { return trackID; }
 
-		geo::Length_t X() const { return middlePos.X(); }
-		geo::Length_t Y() const { return middlePos.Y(); }
-		geo::Length_t Z() const { return middlePos.Z(); }
-		double T() const { return middleTime; }
-		double E() const { return edep; }
+    geo::Length_t X() const { return middlePos.X(); }
+    geo::Length_t Y() const { return middlePos.Y(); }
+    geo::Length_t Z() const { return middlePos.Z(); }
+    double T() const { return middleTime; }
+    double E() const { return edep; }
 
-		bool operator<(const SimEnergyDepositLite& rhs) const
-		{
-			if (trackID < rhs.trackID) return true;
-			if (trackID > rhs.trackID) return false;
-			if (middleTime < rhs.middleTime) return true;
-			if (middleTime > rhs.middleTime) return false;
-			if (middlePos.Z() < rhs.Z()) return true;
-			if (middlePos.Z() > rhs.Z()) return false;
-			if (middlePos.Y() < rhs.Y()) return true;
-			if (middlePos.Y() > rhs.Y()) return false;
-			if (middlePos.X() < rhs.X()) return true;
-			if (middlePos.X() > rhs.X()) return false;
-			return (edep > rhs.edep); // sort by _decreasing_ energy
-		}
+    bool operator<(const SimEnergyDepositLite& rhs) const
+    {
+      if (trackID < rhs.trackID) return true;
+      if (trackID > rhs.trackID) return false;
+      if (middleTime < rhs.middleTime) return true;
+      if (middleTime > rhs.middleTime) return false;
+      if (middlePos.Z() < rhs.Z()) return true;
+      if (middlePos.Z() > rhs.Z()) return false;
+      if (middlePos.Y() < rhs.Y()) return true;
+      if (middlePos.Y() > rhs.Y()) return false;
+      if (middlePos.X() < rhs.X()) return true;
+      if (middlePos.X() > rhs.X()) return false;
+      return (edep > rhs.edep); // sort by _decreasing_ energy
+    }
 
-    // Explicit conversion operator to sim::SimEnergyDeposit
-    // (can be useful in some cases to avoid rewriting code)
-    //
     // Need to be aware that information is obviously not complete
     // (e.g. no exact start/end point or time, only middle point or time)
     operator sim::SimEnergyDeposit() const {
@@ -88,15 +82,15 @@ namespace sim
                                   0);
     }
 
-	private:
-		float        edep; ///< energy deposition (MeV)
-		geo::Point_t middlePos; ///< position in (cm)
-		double       middleTime; ///< (ns)
-		int          trackID; ///< simulation track id
+  private:
+    float        edep; ///< energy deposition (MeV)
+    geo::Point_t middlePos; ///< position in (cm)
+    double       middleTime; ///< (ns)
+    int          trackID; ///< simulation track id
 
-	};
+  };
 
-	typedef std::vector<SimEnergyDepositLite> SimEnergyDepositLiteCollection;
+  typedef std::vector<SimEnergyDepositLite> SimEnergyDepositLiteCollection;
 } // namespace sim
 #endif // LARDATAOBJ_SIMULATION_SIMENERGYDEPOSITLITE_H
 

--- a/lardataobj/Simulation/SimEnergyDepositLite.h
+++ b/lardataobj/Simulation/SimEnergyDepositLite.h
@@ -49,6 +49,7 @@ namespace sim
 		int TrackID() const { return trackID; }
 		void setTrackID(int id) { trackID = id; }
 		void setEnergy(double e) { edep = e; }
+    void setTime(double t) { middleTime = t; }
 
 		geo::Length_t X() const { return middlePos.X(); }
 		geo::Length_t Y() const { return middlePos.Y(); }

--- a/lardataobj/Simulation/SimEnergyDepositLite.h
+++ b/lardataobj/Simulation/SimEnergyDepositLite.h
@@ -10,6 +10,7 @@
 // LArSoft includes
 // Define the LArSoft standard geometry types and methods.
 #include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+#include "lardataobj/Simulation/SimEnergyDeposit.h"
 
 // C++ includes
 #include <vector>
@@ -43,6 +44,7 @@ namespace sim
 
 		double Energy() const { return edep; }
 		geo::Point_t Position() const { return { middlePos.X(), middlePos.Y(), middlePos.Z() }; }
+    geo::Point_t MidPoint() const { return Position();} ///< Just an alias for compatibility with SED
 		double Time() const { return middleTime; }
 		int TrackID() const { return trackID; }
 		void setTrackID(int id) { trackID = id; }
@@ -68,6 +70,22 @@ namespace sim
 			if (middlePos.X() > rhs.X()) return false;
 			return (edep > rhs.edep); // sort by _decreasing_ energy
 		}
+
+    // Explicit conversion operator to sim::SimEnergyDeposit
+    // (can be useful in some cases to avoid rewriting code)
+    //
+    // Need to be aware that information is obviously not complete
+    // (e.g. no exact start/end point or time, only middle point or time)
+    operator sim::SimEnergyDeposit() const {
+      return sim::SimEnergyDeposit(0, 0, 0,
+                                  edep,
+                                  middlePos,
+                                  middlePos,
+                                  middleTime,
+                                  middleTime,
+                                  trackID,
+                                  0);
+    }
 
 	private:
 		float        edep; ///< energy deposition (MeV)

--- a/lardataobj/Simulation/SimEnergyDepositLite.h
+++ b/lardataobj/Simulation/SimEnergyDepositLite.h
@@ -1,0 +1,83 @@
+//////////////////////////////////////////////////////////////////////
+/// \file  lardataobj/Simulation/SimEnergyDepositLite.h
+/// \brief contains information for a single step in the detector simulation
+///					(pared down in size to the essential information)
+/// \authors Laura Domine
+////////////////////////////////////////////////////////////////////////
+#ifndef LARDATAOBJ_SIMULATION_SIMENERGYDEPOSITLITE_H
+#define LARDATAOBJ_SIMULATION_SIMENERGYDEPOSITLITE_H
+
+// LArSoft includes
+// Define the LArSoft standard geometry types and methods.
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+
+// C++ includes
+#include <vector>
+
+namespace sim
+{
+  /**
+   * @brief Energy deposition in the active material (lite version).
+   *
+   * The detector simulation (presently LArG4, which invokes Geant4)
+	 * propagates particles through the detector in intervals of "steps".
+	 * These are usually stored in sim::SimEnergyDeposit objects. For
+	 * filesize concerns we pare it down to the essential information.
+	 */
+	class SimEnergyDepositLite
+	{
+	public:
+
+		using Length_t = float;
+		using Point_t = geo::Point_t;
+
+		SimEnergyDepositLite(double e = 0.,
+												geo::Point_t middle = {0., 0., 0.},
+												double t = 0.,
+												int id = 0)
+											: edep(e)
+											, middlePos(middle)
+											, middleTime(t)
+											, trackID(id)
+		{}
+
+		double Energy() const { return edep; }
+		geo::Point_t Position() const { return { middlePos.X(), middlePos.Y(), middlePos.Z() }; }
+		double Time() const { return middleTime; }
+		int TrackID() const { return trackID; }
+		void setTrackID(int id) { trackID = id; }
+		void setEnergy(double e) { edep = e; }
+
+		geo::Length_t X() const { return middlePos.X(); }
+		geo::Length_t Y() const { return middlePos.Y(); }
+		geo::Length_t Z() const { return middlePos.Z(); }
+		double T() const { return middleTime; }
+		double E() const { return edep; }
+
+		bool operator<(const SimEnergyDepositLite& rhs) const
+		{
+			if (trackID < rhs.trackID) return true;
+			if (trackID > rhs.trackID) return false;
+			if (middleTime < rhs.middleTime) return true;
+			if (middleTime > rhs.middleTime) return false;
+			if (middlePos.Z() < rhs.Z()) return true;
+			if (middlePos.Z() > rhs.Z()) return false;
+			if (middlePos.Y() < rhs.Y()) return true;
+			if (middlePos.Y() > rhs.Y()) return false;
+			if (middlePos.X() < rhs.X()) return true;
+			if (middlePos.X() > rhs.X()) return false;
+			return (edep > rhs.edep); // sort by _decreasing_ energy
+		}
+
+	private:
+		float        edep; ///< energy deposition (MeV)
+		geo::Point_t middlePos; ///< position in (cm)
+		double       middleTime; ///< (ns)
+		int          trackID; ///< simulation track id
+
+	};
+
+	typedef std::vector<SimEnergyDepositLite> SimEnergyDepositLiteCollection;
+} // namespace sim
+#endif // LARDATAOBJ_SIMULATION_SIMENERGYDEPOSITLITE_H
+

--- a/lardataobj/Simulation/classes.h
+++ b/lardataobj/Simulation/classes.h
@@ -15,6 +15,7 @@
 
 // Simulation includes
 #include "lardataobj/Simulation/SimEnergyDeposit.h"
+#include "lardataobj/Simulation/SimEnergyDepositLite.h"
 #include "lardataobj/Simulation/AuxDetHit.h"
 #include "lardataobj/Simulation/SimChannel.h"
 #include "lardataobj/Simulation/OpDetBacktrackerRecord.h"

--- a/lardataobj/Simulation/classes_def.xml
+++ b/lardataobj/Simulation/classes_def.xml
@@ -33,8 +33,8 @@
  </class>
  <class name="std::vector< sim::SimEnergyDeposit>"/>
  <class name="art::Wrapper< std::vector< sim::SimEnergyDeposit>>"/>
- <class name="sim::SimEnergyDepositLite" ClassVersion="13" >
-  <version ClassVersion="13" checksum="3186052868"/>
+ <class name="sim::SimEnergyDepositLite" ClassVersion="10" >
+  <version ClassVersion="10" checksum="3186052868"/>
  </class>
  <class name="std::vector< sim::SimEnergyDepositLite>"/>
  <class name="art::Wrapper< std::vector< sim::SimEnergyDepositLite>>"/>

--- a/lardataobj/Simulation/classes_def.xml
+++ b/lardataobj/Simulation/classes_def.xml
@@ -33,6 +33,11 @@
  </class>
  <class name="std::vector< sim::SimEnergyDeposit>"/>
  <class name="art::Wrapper< std::vector< sim::SimEnergyDeposit>>"/>
+ <class name="sim::SimEnergyDepositLite" ClassVersion="13" >
+  <version ClassVersion="13" checksum="3186052868"/>
+ </class>
+ <class name="std::vector< sim::SimEnergyDepositLite>"/>
+ <class name="art::Wrapper< std::vector< sim::SimEnergyDepositLite>>"/>
  <class name="std::vector< sim::AuxDetHit>"/>
  <class name="art::Wrapper< std::vector< sim::AuxDetHit>>"/>
  <class name="sim::SimPhotonsLite" ClassVersion="10">
@@ -84,6 +89,7 @@
  <class name="art::Assns<sim::SupernovaTruth, simb::MCTruth, void>"/>
  <class name="art::Assns<simb::MCTruth, sim::SupernovaTruth, void>"/>
  <class name="std::vector<sim::SimEnergyDeposit>"/>
+ <class name="std::vector<sim::SimEnergyDepositLite>"/>
  <class name="std::vector<sim::AuxDetHit>"/>
  <class name="std::vector<sim::OnePhoton>"/>
  <class name="std::vector<sim::SimPhotonsLite>"/>
@@ -108,6 +114,7 @@
  <class name="art::Wrapper< std::vector<sim::SimPhotonsLite>>"/>
  <class name="art::Wrapper< std::vector<sim::SimChannel>>"/>
  <class name="art::Wrapper< std::vector<sim::SimEnergyDeposit>>"/>
+ <class name="art::Wrapper< std::vector<sim::SimEnergyDepositLite>>"/>
  <class name="art::Wrapper< std::vector<sim::AuxDetHit>>"/>
  <class name="art::Wrapper< std::vector<sim::BeamGateInfo>>"/>
  <class name="art::Wrapper< std::vector<sim::AuxDetSimChannel>>"/>


### PR DESCRIPTION
This PR is part of an effort from the ICARUS ML group to merge our pipeline back into the official production workflow.

* Create `sim::SimEnergyDepositLite` class, a lite version of `sim::SimEnergyDeposit`, with conversion to/from `sim::SimEnergyDeposit`
* Move `sim::MCMiniPart` (lite version of `simb::MCParticle`) from `larsim/MCST/MCRecoPart.h` and add some conversion operators to `simb::MCParticle`