### PR TITLE
Added dumper for `recob::OpHit` and `recob::OpFlash` [2/2]

### DIFF
--- a/lardataobj/RecoBase/OpFlash.cxx
+++ b/lardataobj/RecoBase/OpFlash.cxx
@@ -9,7 +9,9 @@
 
 #include "lardataobj/RecoBase/OpFlash.h"
 
-#include <numeric> // std::accumulate()
+#include <algorithm> // std::max()
+#include <numeric>   // std::accumulate()
+#include <ostream>
 #include <utility> // std::move()
 
 namespace recob {
@@ -90,5 +92,81 @@ namespace recob {
   {
     return std::accumulate(fPEperOpDet.begin(), fPEperOpDet.end(), 0.0);
   }
+
+  //----------------------------------------------------------------------
+  std::ostream& operator<<(std::ostream& out, OpFlash const& flash)
+  {
+
+    out << "Optical flash at " << flash.Time() << " us (absolute: " << flash.AbsTime() << " us) "
+        << flash.TimeWidth() << " us long, centered at (";
+    if (flash.hasXCenter())
+      out << flash.XCenter();
+    else
+      out << "?";
+    out << ", " << flash.YCenter() << ", " << flash.ZCenter() << ") cm of extension +/- (";
+    if (flash.hasXCenter())
+      out << flash.XWidth();
+    else
+      out << "?";
+    out << ", " << flash.YWidth() << ", " << flash.ZWidth() << ") cm ";
+    if (!flash.hasXCenter()) out << " (x: n/a)";
+
+    out << "\n  " << (flash.InBeamFrame() ? "" : "not ")
+        << "in beam frame (on beam time: " << flash.OnBeamTime() << ")";
+
+    out << "\n  total p.e.: " << flash.TotalPE() << " (fast/total fraction: " << flash.FastToTotal()
+        << ")";
+    std::size_t const nPEs = flash.PEs().size();
+    if (nPEs > 0) {
+      out << " across " << nPEs << " channels; non-empty:";
+      constexpr unsigned int pageSize = 8;
+      unsigned int line = 0;
+      for (std::size_t i = 0; i < nPEs; ++i) {
+        double const pe = flash.PE(i);
+        if (pe == 0.0) continue;
+        if (line-- == 0) {
+          line = pageSize;
+          out << "\n  ";
+        }
+        out << "  [" << i << "] " << pe;
+      }
+    }
+    else {
+      out << ", no channels recorded;";
+    }
+
+    std::size_t const nWireCenters = flash.WireCenters().size();
+    std::size_t const nWireWidths = flash.WireWidths().size();
+    std::size_t const nWires = std::max(nWireCenters, nWireWidths);
+    out << "\n  ";
+    if (nWires) {
+      out << nWires << " wires recorded (center +/- width):";
+      constexpr unsigned int pageSize = 5;
+      unsigned int line = 0;
+      for (std::size_t i = 0; i < nWires; ++i) {
+        if (line-- == 0) {
+          line = pageSize;
+          out << "\n  ";
+        }
+        out << "  [" << i << "] (";
+        if (i < nWireCenters)
+          out << flash.WireCenters()[i];
+        else
+          out << "n/a";
+        out << " +/- ";
+        if (i < nWireWidths)
+          out << flash.WireWidths()[i];
+        else
+          out << "n/a";
+        out << ")";
+      }
+    }
+    else
+      out << "no wire information recorded";
+
+    return out;
+  } // std::ostream& operator<<(std::ostream&, OpFlash const&)
+
+  //----------------------------------------------------------------------
 
 }

--- a/lardataobj/RecoBase/OpFlash.h
+++ b/lardataobj/RecoBase/OpFlash.h
@@ -9,6 +9,7 @@
 #ifndef OPFLASH_H
 #define OPFLASH_H
 
+#include <iosfwd> // std::ostream
 #include <limits> // std::numeric_limits<>
 #include <vector>
 
@@ -106,6 +107,11 @@ namespace recob {
     double TotalPE() const;
     double FastToTotal() const;
   };
+
+  /// Human-readable, almost-complete dump of the `hit` content.
+  ///
+  /// `Frame()` value is not printed. No end-of-line added.
+  std::ostream& operator<<(std::ostream& out, OpFlash const& flash);
 
 }
 

--- a/lardataobj/RecoBase/OpHit.cxx
+++ b/lardataobj/RecoBase/OpHit.cxx
@@ -9,6 +9,8 @@
 
 #include "lardataobj/RecoBase/OpHit.h"
 
+#include <ostream>
+
 namespace recob {
 
   //----------------------------------------------------------------------
@@ -77,4 +79,21 @@ namespace recob {
   //----------------------------------------------------------------------
   bool operator<(const OpHit& a, const OpHit& b) { return a.PE() < b.PE(); }
 
+  //----------------------------------------------------------------------
+  std::ostream& operator<<(std::ostream& out, OpHit const& hit)
+  {
+    // single line output
+
+    out << "Hit on optical channel " << hit.OpChannel();
+    if (hit.HasStartTime()) out << " starting at " << hit.StartTime();
+    out << " us, peak at " << hit.PeakTime() << " us (absolute: " << hit.PeakTimeAbs() << " us)";
+    if (hit.RiseTime() != OpHit::DefaultTime) out << "; rise time: " << hit.RiseTime() << " us";
+    out << "; width " << hit.Width() << " us, amplitude " << hit.Amplitude() << " ADC#, integral "
+        << hit.Area() << " ADC#, " << hit.PE() << " photoelectrons";
+    if (hit.FastToTotal() > 0.0) out << "; fast fraction: " << hit.FastToTotal();
+
+    return out;
+  }
+
+  //----------------------------------------------------------------------
 }

--- a/lardataobj/RecoBase/OpHit.h
+++ b/lardataobj/RecoBase/OpHit.h
@@ -9,6 +9,7 @@
 #ifndef OPHIT_H
 #define OPHIT_H
 
+#include <iosfwd> // std::ostream
 #include <limits>
 
 namespace recob {
@@ -74,6 +75,12 @@ namespace recob {
     //Returns true if the StartTime has been initialized
     bool HasStartTime() const;
   };
+
+  /// Human-readable, single-line almost-complete dump of the `hit` content.
+  ///
+  /// `Frame()` value is not printed. No end-of-line added.
+  std::ostream& operator<<(std::ostream& out, OpHit const& hit);
+
 }
 
 inline int recob::OpHit::OpChannel() const


### PR DESCRIPTION
This pull request adds stream output for `recob::OpHit` and `recob::OpFlash` data product classes.

This is dependent of pull request LArSoft/lardata#31. All general comments should go there.
