### PR TITLE
Particle Ancestry Map Fix

### DIFF
--- a/lardataobj/Simulation/ParticleAncestryMap.cxx
+++ b/lardataobj/Simulation/ParticleAncestryMap.cxx
@@ -9,17 +9,17 @@ namespace sim {
 
   std::map<int, std::set<int>> const& ParticleAncestryMap::GetMap() const { return fParticleMap; }
 
-  bool ParticleAncestryMap::HasDroppedDescendants(const int trackid)
+  bool ParticleAncestryMap::HasDroppedDescendants(const int trackid) const
   {
     return fParticleMap.count(trackid) != 0;
   }
 
-  std::set<int> const& ParticleAncestryMap::GetAllDroppedDescendants(const int trackid)
+  std::set<int> const& ParticleAncestryMap::GetAllDroppedDescendants(const int trackid) const
   {
-    return fParticleMap[trackid];
+    return fParticleMap.at(trackid);
   }
 
-  int ParticleAncestryMap::GetAncestor(const int trackid)
+  int ParticleAncestryMap::GetAncestor(const int trackid) const
   {
     for (auto const& [ancestor, descendants] : fParticleMap) {
       if (descendants.count(trackid) != 0) return ancestor;
@@ -28,7 +28,7 @@ namespace sim {
     return -std::numeric_limits<int>::max();
   }
 
-  bool ParticleAncestryMap::Exists(const int trackid)
+  bool ParticleAncestryMap::Exists(const int trackid) const
   {
     return trackid != -std::numeric_limits<int>::max();
   }

--- a/lardataobj/Simulation/ParticleAncestryMap.h
+++ b/lardataobj/Simulation/ParticleAncestryMap.h
@@ -36,16 +36,16 @@ namespace sim {
     std::map<int, std::set<int>> const& GetMap() const;
 
     // Whether there are any dropped descendants for a given track id
-    bool HasDroppedDescendants(const int trackid);
+    bool HasDroppedDescendants(const int trackid) const;
 
     // Return the set of dropped descendants from a given ancestor's track id
-    std::set<int> const& GetAllDroppedDescendants(const int trackid);
+    std::set<int> const& GetAllDroppedDescendants(const int trackid) const;
 
     // Get the stored ancestor from a given dropped track id
-    int GetAncestor(const int trackid);
+    int GetAncestor(const int trackid) const;
 
     // Whether or not the returned track id from GetAncestor is valid or set to the default value
-    bool Exists(const int trackid);
+    bool Exists(const int trackid) const;
   };
 }
 #endif


### PR DESCRIPTION
When this object was created in #34 I mistakenly did not declare the member functions to be const. This causes problems for obvious reasons when this object is used after being written to the artroot file. This PR should address that.