### PR TITLE
gcc 13 fixes

### DIFF
--- a/lardataobj/RawData/AuxDetDigit.h
+++ b/lardataobj/RawData/AuxDetDigit.h
@@ -9,6 +9,7 @@
 #ifndef RAWDATA_AUXDETDIGIT_H
 #define RAWDATA_AUXDETDIGIT_H
 
+#include <cstdint>
 #include <iosfwd>
 #include <string>
 #include <vector>

--- a/lardataobj/RawData/BeamInfo.h
+++ b/lardataobj/RawData/BeamInfo.h
@@ -5,6 +5,7 @@
 #ifndef RAWDATA_BEAMINFO_H
 #define RAWDATA_BEAMINFO_H
 
+#include <cstdint>
 #include <iosfwd>
 #include <map>
 #include <string>


### PR DESCRIPTION
Avoid undefined uint16_t / uint32_t errors in gcc 13.x