### PR TITLE
Refactor MC collections according to GCC errors

### DIFF
--- a/lardataobj/MCBase/MCHitCollection.cxx
+++ b/lardataobj/MCBase/MCHitCollection.cxx
@@ -1,1 +1,18 @@
 #include "lardataobj/MCBase/MCHitCollection.h"
+
+#include <algorithm>
+
+sim::MCHitCollection::MCHitCollection(unsigned int const ch) : fChannel{ch} {}
+
+void sim::MCHitCollection::Reset()
+{
+  *this = MCHitCollection{};
+}
+
+void sim::MCHitCollection::push_back(MCHit const& hit)
+{
+  bool sort = !empty() && hit < *rbegin();
+
+  std::vector<sim::MCHit>::push_back(hit);
+  if (sort) std::sort(begin(), end());
+}

--- a/lardataobj/MCBase/MCHitCollection.h
+++ b/lardataobj/MCBase/MCHitCollection.h
@@ -1,4 +1,3 @@
-
 #ifndef MCHITCOLLECTION_H
 #define MCHITCOLLECTION_H
 
@@ -9,42 +8,17 @@
 namespace sim {
 
   class MCHitCollection : public std::vector<sim::MCHit> {
-
   public:
-    /// Default ctor
-    MCHitCollection(const unsigned int ch = ::sim::kINVALID_UINT)
-    {
-      Reset();
-      fChannel = ch;
-    }
+    MCHitCollection(const unsigned int ch = ::sim::kINVALID_UINT);
 
-    /// Method to reset
-    void Reset()
-    {
-      fChannel = ::sim::kINVALID_UINT;
-      std::vector<sim::MCHit>::clear();
-    }
+    void Reset();
+    void push_back(MCHit const& hit);
+
+    unsigned int Channel() const { return fChannel; }
+    bool operator<(MCHitCollection const& rhs) const { return fChannel < rhs.fChannel; }
 
   private:
-    unsigned int fChannel; ///< Channel number
-
-  public:
-    /// Getter for channel number
-    unsigned int Channel() const { return fChannel; }
-
-    /// For sorting
-    inline bool operator<(const MCHitCollection& rhs) const { return fChannel < rhs.fChannel; }
-
-    /// wrapper for push_back
-    inline void push_back(const MCHit& hit)
-    {
-
-      bool sort = (!empty() && hit < (*rbegin()));
-
-      std::vector<sim::MCHit>::push_back(hit);
-
-      if (sort) std::sort(begin(), end());
-    }
+    unsigned int fChannel;
   };
 }
 
@@ -53,9 +27,9 @@ namespace std {
   template <>
   class less<sim::MCHitCollection*> {
   public:
-    bool operator()(const sim::MCHitCollection* lhs, const sim::MCHitCollection* rhs)
+    bool operator()(sim::MCHitCollection const* lhs, sim::MCHitCollection const* rhs) const
     {
-      return (*lhs) < (*rhs);
+      return *lhs < *rhs;
     }
   };
 }

--- a/lardataobj/MCBase/MCWireCollection.cxx
+++ b/lardataobj/MCBase/MCWireCollection.cxx
@@ -1,1 +1,18 @@
 #include "lardataobj/MCBase/MCWireCollection.h"
+
+#include <algorithm>
+
+sim::MCWireCollection::MCWireCollection(unsigned int const ch) : fChannel{ch} {}
+
+void sim::MCWireCollection::Reset()
+{
+  *this = MCWireCollection();
+}
+
+void sim::MCWireCollection::push_back(MCWire const& wire)
+{
+  bool sort = !empty() && wire < *rbegin();
+
+  std::vector<sim::MCWire>::push_back(wire);
+  if (sort) std::sort(begin(), end());
+}

--- a/lardataobj/MCBase/MCWireCollection.h
+++ b/lardataobj/MCBase/MCWireCollection.h
@@ -1,4 +1,3 @@
-
 #ifndef MCWIRECOLLECTION_H
 #define MCWIRECOLLECTION_H
 
@@ -8,41 +7,17 @@
 namespace sim {
 
   class MCWireCollection : public std::vector<sim::MCWire> {
-
   public:
-    /// Default ctor
-    MCWireCollection(const unsigned int ch = sim::kINVALID_UINT)
-    {
-      Reset();
-      fChannel = ch;
-    }
+    MCWireCollection(unsigned int const ch = sim::kINVALID_UINT);
 
-    void Reset()
-    {
-      std::vector<sim::MCWire>::clear();
-      fChannel = sim::kINVALID_UINT;
-    }
+    unsigned int Channel() const { return fChannel; }
+    bool operator<(MCWireCollection const& rhs) const { return fChannel < rhs.fChannel; }
+
+    void Reset();
+    void push_back(MCWire const& wire);
 
   private:
     unsigned int fChannel;
-
-  public:
-    /// Getter for channel number
-    unsigned int Channel() const { return fChannel; }
-
-    /// For sorting
-    inline bool operator<(const MCWireCollection& rhs) const { return fChannel < rhs.fChannel; }
-
-    /// wrapper for push_back
-    inline void push_back(const MCWire& wire)
-    {
-
-      bool sort = (!empty() && wire < (*rbegin()));
-
-      std::vector<sim::MCWire>::push_back(wire);
-
-      if (sort) std::sort(begin(), end());
-    }
   };
 }
 
@@ -51,9 +26,9 @@ namespace std {
   template <>
   class less<sim::MCWireCollection*> {
   public:
-    bool operator()(const sim::MCWireCollection* lhs, const sim::MCWireCollection* rhs)
+    bool operator()(sim::MCWireCollection const* lhs, sim::MCWireCollection const* rhs) const
     {
-      return (*lhs) < (*rhs);
+      return *lhs < *rhs;
     }
   };
 }


### PR DESCRIPTION
GCC 14 complains that `#include <algorithm>` is missing from the header files in this PR.  Those headers call `std::sort(...)`, and such an invocation belongs in the `.cxx` files.  This PR refactors the header files such that `std::sort(...)` occurs in the `.cxx` files, and it also includes the missing `#include <algorithm>` statement.