### PR TITLE
Add associations between OpDetWaveform and RDTimeStamp

### DIFF
--- a/lardataobj/RawData/classes_def.xml
+++ b/lardataobj/RawData/classes_def.xml
@@ -85,6 +85,14 @@
  <class name="art::Wrapper< art::Assns<raw::RDTimeStamp, raw::RawDigit, void>>"/>
  <class name="art::Wrapper< art::Assns<raw::RawDigit, raw::RDTimeStamp, void>>"/>
 
+ <class name="art::Ptr< raw::OpDetWaveform>"/>
+ <class name="std::pair< art::Ptr< raw::OpDetWaveform>, art::Ptr< raw::RDTimeStamp>>"/>
+ <class name="std::pair< art::Ptr< raw::RDTimeStamp>, art::Ptr< raw::OpDetWaveform>>"/>
+ <class name="art::Assns< raw::RDTimeStamp, raw::OpDetWaveform, void>"/>
+ <class name="art::Assns< raw::OpDetWaveform, raw::RDTimeStamp, void>"/>
+ <class name="art::Wrapper< art::Assns<raw::RDTimeStamp, raw::OpDetWaveform, void>>"/>
+ <class name="art::Wrapper< art::Assns<raw::OpDetWaveform, raw::RDTimeStamp, void>>"/>
+ 
  <ioread 
     version="[-11]" 
     sourceClass="raw::RawDigit" 


### PR DESCRIPTION
The double precision timestamp is commented as being the number of microseconds since January 1, 1970.  But there are more than 1.6E15 microseconds since January 1, 1970 as of this writing, and doubles are only good for 14 digits or so.  So DUNE would like to make RDTimeStamp data products and associate them with OpDetWaveforms.  This association needs these lines in classes_def.xml