### PR TITLE
change emplace_back to insert on MergeSimChannel to retain ordering

### DIFF
--- a/lardataobj/Simulation/SimChannel.cxx
+++ b/lardataobj/Simulation/SimChannel.cxx
@@ -267,8 +267,11 @@ namespace sim {
       // pick which IDE list we have to fill: new one or existing one
       std::vector<sim::IDE>* curIDEVec;
       if (itrthis == fTDCIDEs.end() || itrthis->first != tdc) {
-        fTDCIDEs.emplace_back(tdc, std::vector<sim::IDE>());
-        curIDEVec = &(fTDCIDEs.back().second);
+        //insert at the location where it should be
+        auto newitr = fTDCIDEs.insert(itrthis, {tdc, std::vector<sim::IDE>()} );
+
+        //current IDE vector should be at new position
+        curIDEVec = &(newitr->second);
       }
       else
         curIDEVec = &(itrthis->second);

--- a/lardataobj/Simulation/SimChannel.cxx
+++ b/lardataobj/Simulation/SimChannel.cxx
@@ -264,17 +264,13 @@ namespace sim {
       // find the entry from this SimChannel corresponding to the tdc from the other
       auto itrthis = findClosestTDCIDE(tdc);
 
-      // pick which IDE list we have to fill: new one or existing one
-      std::vector<sim::IDE>* curIDEVec;
+      // if not found, insert at the location where it should be
       if (itrthis == fTDCIDEs.end() || itrthis->first != tdc) {
-        //insert at the location where it should be
-        auto newitr = fTDCIDEs.insert(itrthis, {tdc, std::vector<sim::IDE>()});
-
-        //current IDE vector should be at new position
-        curIDEVec = &(newitr->second);
+        itrthis = fTDCIDEs.insert(itrthis, {tdc, std::vector<sim::IDE>()});
       }
-      else
-        curIDEVec = &(itrthis->second);
+
+      // pick the IDE list we have to fill
+      std::vector<sim::IDE>* curIDEVec = &(itrthis->second);
 
       for (auto const& ide : ides) {
         curIDEVec->emplace_back(ide, offset);

--- a/lardataobj/Simulation/SimChannel.cxx
+++ b/lardataobj/Simulation/SimChannel.cxx
@@ -268,7 +268,7 @@ namespace sim {
       std::vector<sim::IDE>* curIDEVec;
       if (itrthis == fTDCIDEs.end() || itrthis->first != tdc) {
         //insert at the location where it should be
-        auto newitr = fTDCIDEs.insert(itrthis, {tdc, std::vector<sim::IDE>()} );
+        auto newitr = fTDCIDEs.insert(itrthis, {tdc, std::vector<sim::IDE>()});
 
         //current IDE vector should be at new position
         curIDEVec = &(newitr->second);


### PR DESCRIPTION
Joseph Zennamo found what I think is a bug on using SimChannel::MergeSimChannel as part of our merge sim sources workflows (all plots from him).

On trying to merge sim channels, he noticed that some IDEs appear to be missing:
![mergsimchannel_beforefix](https://github.com/user-attachments/assets/f5c62812-dbde-42d1-91a5-85809900dcc6)

On looking at the TDCIDEs in the SimChannel, you can see that while the information is there, the merged collection is not ordered in TDC:
![TDCIDE_ordering_simchannel](https://github.com/user-attachments/assets/6b1a4090-5504-4b60-8a3c-4bf229bd3c3a)

As SimChannel has some tools that assume ordering of the underlying TDCIDE collection, it's perhaps not surprising to see that there may be issues with some aspects when it's not ordered.

Becoming unordered when merging is due to the logic in MergeSimChannel, which when it doesn't find the desired tdc in the exisitng SimChannel (so, we have energy at a TDC that we didn't before), it does an emplace_back rather than insert into the proper place. This PR turns that into an insert. There should be no performance change, because there's already a "findClosestTDC" command called which returns a std::lower_bound, so we already know where we should insert.

After the fix, the example looks something like this:
![mergesimchannel_afterfix](https://github.com/user-attachments/assets/0af59b9a-a695-4ff4-a758-1ba248857f1c)

I'm issuing this PR against develop, but it may be needed against other tags for patch releases.