### PR TITLE
Making OpDetBTR actually use a map

### DIFF
--- a/lardataobj/Simulation/OpDetBacktrackerRecord.cxx
+++ b/lardataobj/Simulation/OpDetBacktrackerRecord.cxx
@@ -9,7 +9,8 @@
 ////////////////////////////////////////////////////////////////////////
 
 #include <algorithm> // std::lower_bound(), std::max()
-#include <limits>    // std::numeric_limits
+#include <iostream>
+#include <limits> // std::numeric_limits
 #include <map>
 #include <stdexcept>
 #include <utility>
@@ -20,6 +21,72 @@
 
 #include "messagefacility/MessageLogger/MessageLogger.h"
 namespace sim {
+
+  void OBTRHelper::AddScintillationPhotonsToMap(
+    // std::map<timePDclock_t, std::vector<sim::SDP>> & timePDclockSDPs,
+    TrackID_t trackID,
+    timePDclock_t iTimePDclock,
+    double numberPhotons,
+    double const* xyz,
+    double energy)
+  {
+    /**
+      * The iTimePDclock from OpFastScintillation (where OpDetBacktrackerRecords originate) is done with CLHEP::ns (units of nanoseconds).
+      */
+    // look at the collection to see if the current iTimePDclock already
+    // exists, if not, add it, if so, just add a new track id to the
+    // vector, or update the information if track is already present
+
+    // no photons? no good!
+    if ((numberPhotons < std::numeric_limits<double>::epsilon()) ||
+        (energy <= std::numeric_limits<double>::epsilon())) {
+      // will throw
+      MF_LOG_ERROR("OpDetBacktrackerRecord")
+        << "AddTrackPhotons() trying to add to iTimePDclock #" << iTimePDclock << " "
+        << numberPhotons << " photons with " << energy
+        << " MeV of energy from track ID=" << trackID;
+      return;
+    } // if no photons
+
+    int rounded_time = std::round(iTimePDclock);
+
+    auto itr = fTimePDclockSDPs.lower_bound(rounded_time);
+
+    // check if this iTimePDclock value is in the vector, it is possible that
+    // the lower bound is different from the given TimePDclock, in which case
+    // we need to add something for that TimePDclock
+    if (itr == fTimePDclockSDPs.end() || fTimePDclockSDPs.key_comp()(rounded_time, itr->first)) {
+      fTimePDclockSDPs.insert(
+        {rounded_time,
+         std::vector<sim::SDP>{sim::SDP(trackID, numberPhotons, energy, xyz[0], xyz[1], xyz[2])}});
+    }
+    else { // we have that iTimePDclock already; itr points to it
+
+      // loop over the SDP vector for this iTimePDclock and add the electrons
+      // to the entry with the same track id
+      for (auto& sdp : itr->second) {
+
+        if (sdp.trackID != trackID) continue;
+
+        // make a weighted average for the location information
+        double weight = sdp.numPhotons + numberPhotons;
+        sdp.x = (sdp.x * sdp.numPhotons + xyz[0] * numberPhotons) / weight;
+        sdp.y = (sdp.y * sdp.numPhotons + xyz[1] * numberPhotons) / weight;
+        sdp.z = (sdp.z * sdp.numPhotons + xyz[2] * numberPhotons) / weight;
+        sdp.numPhotons = weight;
+        sdp.energy = sdp.energy + energy;
+
+        // found the track id we wanted, so return;
+        return;
+      } // for
+
+      // if we never found the track id, then this is the first instance of
+      // the track id for this TimePDclock, so add sdp to the vector
+      itr->second.emplace_back(trackID, numberPhotons, energy, xyz[0], xyz[1], xyz[2]);
+
+    } // end of else "We have that iTimePDclock already"
+
+  } // OBTRHelper::AddIonizationElectrons()
 
   //-------------------------------------------------
   SDP::SDP() //SDP stands for Scintillation Deposited Photons
@@ -49,6 +116,18 @@ namespace sim {
   OpDetBacktrackerRecord::OpDetBacktrackerRecord(int detNum) : iOpDetNum(detNum) {}
 
   //-------------------------------------------------
+  OpDetBacktrackerRecord::OpDetBacktrackerRecord(OBTRHelper& helper) : iOpDetNum(helper.fTrackID)
+  {
+    auto& sdp_map = helper.fTimePDclockSDPs;
+    for (auto& [channel, vec] : sdp_map) {
+
+      // std::cout << "Moving SDP vector for channel " << channel << " with size " << vec.size() << std::endl;
+      timePDclockSDPs.emplace_back((double)channel, std::move(vec));
+      // std::cout << "Moved " << vec.size() << " " << timePDclockSDPs.back().second.size() << std::endl;
+    }
+  }
+
+  //-------------------------------------------------
   void OpDetBacktrackerRecord::AddScintillationPhotons(TrackID_t trackID,
                                                        timePDclock_t iTimePDclock,
                                                        double numberPhotons,
@@ -73,18 +152,23 @@ namespace sim {
       return;
     } // if no photons
 
-    int rounded_time = std::round(iTimePDclock);
+    // int rounded_time = std::round(iTimePDclock);
 
-    // auto itr = findClosestTimePDclockSDP(rounded_time);
-    auto itr = timePDclockSDPs.lower_bound(rounded_time);
+    auto itr = findClosestTimePDclockSDP(iTimePDclock);
+    // auto itr = timePDclockSDPs.lower_bound(rounded_time);
 
     // check if this iTimePDclock value is in the vector, it is possible that
     // the lower bound is different from the given TimePDclock, in which case
     // we need to add something for that TimePDclock
-    if (itr == timePDclockSDPs.end() || timePDclockSDPs.key_comp()(rounded_time, itr->first)) {
-      timePDclockSDPs.insert(
-        {rounded_time,
-         std::vector<sim::SDP>{sim::SDP(trackID, numberPhotons, energy, xyz[0], xyz[1], xyz[2])}});
+    // if (itr == timePDclockSDPs.end() || timePDclockSDPs.key_comp()(rounded_time, itr->first)) {
+    //   timePDclockSDPs.insert(
+    //     {rounded_time,
+    //      std::vector<sim::SDP>{sim::SDP(trackID, numberPhotons, energy, xyz[0], xyz[1], xyz[2])}});
+    if (itr == timePDclockSDPs.end() || (abs(itr->first - iTimePDclock) > .50)) {
+      //itr->first != iTimePDclock){
+      std::vector<sim::SDP> sdplist;
+      sdplist.emplace_back(trackID, numberPhotons, energy, xyz[0], xyz[1], xyz[2]);
+      timePDclockSDPs.emplace(itr, std::round(iTimePDclock), std::move(sdplist));
     }
     else { // we have that iTimePDclock already; itr points to it
 
@@ -119,8 +203,8 @@ namespace sim {
   {
     double numPhotons = 0.;
 
-    // auto itr = findClosestTimePDclockSDP(iTimePDclock);
-    auto itr = timePDclockSDPs.lower_bound(iTimePDclock);
+    auto itr = findClosestTimePDclockSDP(iTimePDclock);
+    // auto itr = timePDclockSDPs.lower_bound(iTimePDclock);
     // check to see if this iTimePDclock value is in the map
     if (itr != timePDclockSDPs.end() && itr->first == iTimePDclock) {
 
@@ -141,8 +225,8 @@ namespace sim {
   {
     double energy = 0.;
 
-    // auto itr = findClosestTimePDclockSDP(iTimePDclock);
-    auto itr = timePDclockSDPs.lower_bound(iTimePDclock);
+    auto itr = findClosestTimePDclockSDP(iTimePDclock);
+    // auto itr = timePDclockSDPs.lower_bound(iTimePDclock);
 
     // check to see if this iTimePDclock value is in the map
     if (itr != timePDclockSDPs.end() && itr->first == iTimePDclock) {
@@ -176,8 +260,8 @@ namespace sim {
     std::map<TrackID_t, sim::SDP> idToSDP;
 
     //find the lower bound for this iTimePDclock and then iterate from there
-    // auto itr = findClosestTimePDclockSDP(startTimePDclock);
-    auto itr = timePDclockSDPs.lower_bound(startTimePDclock);
+    auto itr = findClosestTimePDclockSDP(startTimePDclock);
+    // auto itr = timePDclockSDPs.lower_bound(startTimePDclock);
 
     while (itr != timePDclockSDPs.end()) {
 
@@ -268,15 +352,22 @@ namespace sim {
     std::pair<TrackID_t, TrackID_t> range_trackID(std::numeric_limits<int>::max(),
                                                   std::numeric_limits<int>::min());
 
-    for (auto const& [iTimePDclock, sdps] : channel.timePDclockSDPsMap()) {
+    // for (auto const& [iTimePDclock, sdps] : channel.timePDclockSDPsMap()) {
+    for (auto const& itr : channel.timePDclockSDPsMap()) {
 
+      auto iTimePDclock = itr.first;
+      auto const& sdps = itr.second;
       // find the entry from this OpDetBacktrackerRecord corresponding to the iTimePDclock from the other
-      auto itrthis = timePDclockSDPs.lower_bound(iTimePDclock);
+      // auto itrthis = timePDclockSDPs.lower_bound(iTimePDclock);
+      auto itrthis = findClosestTimePDclockSDP(iTimePDclock);
+
       // pick which SDP list we have to fill: new one or existing one
       std::vector<sim::SDP>* curSDPVec;
       if (itrthis == timePDclockSDPs.end() || itrthis->first != iTimePDclock) {
-        curSDPVec =
-          &(timePDclockSDPs.insert({iTimePDclock, std::vector<sim::SDP>()}).first->second);
+        timePDclockSDPs.emplace_back(iTimePDclock, std::vector<sim::SDP>());
+        curSDPVec = &(timePDclockSDPs.back().second);
+        // curSDPVec =
+        //   &(timePDclockSDPs.insert({iTimePDclock, std::vector<sim::SDP>()}).first->second);
       }
       else
         curSDPVec = &(itrthis->second);
@@ -292,4 +383,40 @@ namespace sim {
 
     return range_trackID;
   }
+
+  //-------------------------------------------------
+  struct OpDetBacktrackerRecord::CompareByTimePDclock {
+
+    bool operator()(timePDclockSDP_t const& a, timePDclockSDP_t const& b) const
+    {
+      return a.first < b.first;
+    }
+
+    bool operator()(storedTimePDclock_t a_TimePDclock, timePDclockSDP_t const& b) const
+    {
+      return a_TimePDclock < b.first;
+    }
+
+    bool operator()(timePDclockSDP_t const& a, storedTimePDclock_t b_TimePDclock) const
+    {
+      return a.first < b_TimePDclock;
+    }
+
+  }; // struct CompareByTimePDclock
+
+  OpDetBacktrackerRecord::timePDclockSDPs_t::iterator
+  OpDetBacktrackerRecord::findClosestTimePDclockSDP(storedTimePDclock_t iTimePDclock)
+  {
+    return std::lower_bound(
+      timePDclockSDPs.begin(), timePDclockSDPs.end(), iTimePDclock, CompareByTimePDclock());
+  }
+
+  OpDetBacktrackerRecord::timePDclockSDPs_t::const_iterator
+  OpDetBacktrackerRecord::findClosestTimePDclockSDP(storedTimePDclock_t TimePDclock) const
+  {
+    return std::lower_bound(
+      timePDclockSDPs.begin(), timePDclockSDPs.end(), TimePDclock, CompareByTimePDclock());
+  }
+
+  //-------------------------------------------------
 }

--- a/lardataobj/Simulation/OpDetBacktrackerRecord.cxx
+++ b/lardataobj/Simulation/OpDetBacktrackerRecord.cxx
@@ -82,12 +82,9 @@ namespace sim {
     // the lower bound is different from the given TimePDclock, in which case
     // we need to add something for that TimePDclock
     if (itr == timePDclockSDPs.end() || timePDclockSDPs.key_comp()(rounded_time, itr->first)) {
-      timePDclockSDPs.insert({
-        rounded_time, 
-        std::vector<sim::SDP>{
-          sim::SDP(trackID, numberPhotons, energy, xyz[0], xyz[1], xyz[2])
-        }
-      });
+      timePDclockSDPs.insert(
+        {rounded_time,
+         std::vector<sim::SDP>{sim::SDP(trackID, numberPhotons, energy, xyz[0], xyz[1], xyz[2])}});
     }
     else { // we have that iTimePDclock already; itr points to it
 
@@ -278,7 +275,8 @@ namespace sim {
       // pick which SDP list we have to fill: new one or existing one
       std::vector<sim::SDP>* curSDPVec;
       if (itrthis == timePDclockSDPs.end() || itrthis->first != iTimePDclock) {
-        curSDPVec = &(timePDclockSDPs.insert({iTimePDclock, std::vector<sim::SDP>()}).first->second);
+        curSDPVec =
+          &(timePDclockSDPs.insert({iTimePDclock, std::vector<sim::SDP>()}).first->second);
       }
       else
         curSDPVec = &(itrthis->second);

--- a/lardataobj/Simulation/OpDetBacktrackerRecord.h
+++ b/lardataobj/Simulation/OpDetBacktrackerRecord.h
@@ -12,10 +12,10 @@
 #define LARSIMOBJ_SIMULATION_OPDETBACKTRACKERRECORD_H
 
 // C/C++ standard libraries
+#include <map>
 #include <string>
 #include <utility> // std::pair
 #include <vector>
-#include <map> 
 namespace sim {
 
   /// Ionization photons from a Geant4 track

--- a/lardataobj/Simulation/OpDetBacktrackerRecord.h
+++ b/lardataobj/Simulation/OpDetBacktrackerRecord.h
@@ -15,7 +15,7 @@
 #include <string>
 #include <utility> // std::pair
 #include <vector>
-
+#include <map> 
 namespace sim {
 
   /// Ionization photons from a Geant4 track
@@ -83,7 +83,7 @@ namespace sim {
   };                   // struct SDP
 
   /// List of energy deposits at the same time (on this Optical Detector)
-  typedef std::pair<double, std::vector<sim::SDP>> timePDclockSDP_t;
+  typedef std::pair<int, std::vector<sim::SDP>> timePDclockSDP_t;
 
   /**
    * @brief Energy deposited on a readout Optical Detector by simulated tracks
@@ -108,7 +108,8 @@ namespace sim {
     typedef timePDclockSDP_t::first_type storedTimePDclock_t;
 
     /// Type of list of energy deposits for each timePDclock with signal
-    typedef std::vector<timePDclockSDP_t> timePDclockSDPs_t;
+    // typedef std::vector<timePDclockSDP_t> timePDclockSDPs_t;
+    typedef std::map<storedTimePDclock_t, std::vector<sim::SDP>> timePDclockSDPs_t;
 
   private:
     int iOpDetNum;                     ///< OpticalDetector where the photons were detected
@@ -186,6 +187,9 @@ namespace sim {
     /// Returns the total energy on this Optical Detector in the specified iTimePDclock [MeV]
     double Energy(timePDclock_t iTimePDclock) const;
 
+    // /// Sorts the timeClockSDPs by increasing timePDclock tick
+    // void SortTimePDclockSDPs();
+
     /**
      * @brief Returns energies collected for each track within a time interval
      * @param startTimePDclock iTimePDclock tick opening the time window
@@ -262,17 +266,6 @@ namespace sim {
     {
       Dump(std::forward<Stream>(out), indent, indent);
     }
-
-  private:
-    /// Comparison functor, sorts by increasing timePDclocktick value
-    struct CompareByTimePDclock;
-
-    /// Return the iterator to the first timePDclockSDP not earlier than timePDclock
-    timePDclockSDPs_t::iterator findClosestTimePDclockSDP(storedTimePDclock_t timePDclock);
-
-    /// Return the (constant) iterator to the first timePDclockSDP not earlier than timePDclock
-    timePDclockSDPs_t::const_iterator findClosestTimePDclockSDP(
-      storedTimePDclock_t timePDclock) const;
   };
 
 } // namespace sim

--- a/lardataobj/Simulation/classes_def.xml
+++ b/lardataobj/Simulation/classes_def.xml
@@ -69,7 +69,8 @@
   <version ClassVersion="11" checksum="1122283400"/>
   <version ClassVersion="10" checksum="2225942541"/>
  </class>
- <class name="sim::OpDetBacktrackerRecord" ClassVersion="11">
+ <class name="sim::OpDetBacktrackerRecord" ClassVersion="12">
+  <version ClassVersion="12" checksum="1589953796"/>
   <version ClassVersion="11" checksum="1336777815"/>
   <version ClassVersion="10" checksum="2389124613"/>
  </class>
@@ -108,8 +109,8 @@
  <class name="std::vector<sim::TDCIDE>"/>
  <class name="sim::SDP"/>
  <class name="std::vector<sim::SDP>"/>
- <class name="std::pair< double, std::vector<sim::SDP>>"/>
- <class name="std::vector< std::pair < double, std::vector<sim::SDP>>>"/>
+ <class name="std::pair< int, std::vector<sim::SDP>>"/>
+ <class name="std::map<int, std::vector<sim::SDP>>"/>
  <class name="art::Wrapper< std::vector<sim::SimPhotons>>"/>
  <class name="art::Wrapper< std::vector<sim::SimPhotonsLite>>"/>
  <class name="art::Wrapper< std::vector<sim::SimChannel>>"/>

--- a/lardataobj/Simulation/classes_def.xml
+++ b/lardataobj/Simulation/classes_def.xml
@@ -69,7 +69,7 @@
   <version ClassVersion="11" checksum="1122283400"/>
   <version ClassVersion="10" checksum="2225942541"/>
  </class>
- <class name="sim::OpDetBacktrackerRecord" ClassVersion="12">
+ <class name="sim::OpDetBacktrackerRecord" ClassVersion="11">
   <version ClassVersion="12" checksum="1589953796"/>
   <version ClassVersion="11" checksum="1336777815"/>
   <version ClassVersion="10" checksum="2389124613"/>
@@ -109,8 +109,8 @@
  <class name="std::vector<sim::TDCIDE>"/>
  <class name="sim::SDP"/>
  <class name="std::vector<sim::SDP>"/>
- <class name="std::pair< int, std::vector<sim::SDP>>"/>
- <class name="std::map<int, std::vector<sim::SDP>>"/>
+ <class name="std::pair< double, std::vector<sim::SDP>>"/>
+ <class name="std::vector< std::pair < double, std::vector<sim::SDP>>>"/>
  <class name="art::Wrapper< std::vector<sim::SimPhotons>>"/>
  <class name="art::Wrapper< std::vector<sim::SimPhotonsLite>>"/>
  <class name="art::Wrapper< std::vector<sim::SimChannel>>"/>


### PR DESCRIPTION
New implementation of internal map of time --> vector of SDP (Scintillation Deposited Photons). Previously this was a vector of pairs, and there were some attempts to make this behave like a map c.f. [sorting by time in PhotonBackTracker in larsim](https://github.com/LArSoft/larsim/blob/v10_00_04/larsim/MCCheater/PhotonBackTracker.cc#L303-L316) ; in adding scintillation photons, the time was [rounded to the nearest int ](https://github.com/LArSoft/lardataobj/blob/v10_00_02/lardataobj/Simulation/OpDetBacktrackerRecord.cxx#L86)(but then converted to double); also in adding scintillation photons, the trick of[ finding the lower bound and inserting at that point](https://github.com/LArSoft/lardataobj/blob/v10_00_02/lardataobj/Simulation/OpDetBacktrackerRecord.cxx#L77-L87) was used (see [this stack overflow](https://stackoverflow.com/questions/97050/stdmap-insert-or-stdmap-find)), however, because this was a vector and not a map, the contiguous memory of the vector payload would have to be moved around. For maps, this is not necessary.


This created a huge overhead and made this take forever depending on the number of photons. This change reduces the time taken to simulate ProtoDUNEHD using the PDFastSimPAR implementation by a factor of 14 in one example event

larsoft v10_04_07, dunesw v10_04_07d01
```================================================================================================================================
TimeTracker printout (sec)                        Min           Avg           Max         Median          RMS         nEvts   
================================================================================================================================
Full event                                      877.381       877.381       877.381       877.381          0            1     
--------------------------------------------------------------------------------------------------------------------------------
source:RootInput(read)                        0.000246655   0.000246655   0.000246655   0.000246655        0            1     
simulate:rns:RandomNumberSaver                0.000128237   0.000128237   0.000128237   0.000128237        0            1     
simulate:IonAndScint:IonAndScint                1.07221       1.07221       1.07221       1.07221          0            1     
simulate:PDFastSim:PDFastSimPAR                 853.113       853.113       853.113       853.113          0            1     
[art]:TriggerResults:TriggerResultInserter    2.4555e-05    2.4555e-05    2.4555e-05    2.4555e-05         0            1     
end_path:out1:RootOutput                       9.318e-06     9.318e-06     9.318e-06     9.318e-06         0            1     
end_path:out1:RootOutput(write)                 23.1952       23.1952       23.1952       23.1952          0            1     
================================================================================================================================
%MSG-i NuRandomService:  RootOutput:out1@EndJob 07-Apr-2025 14:33:49 EDT  ModuleEndJob

Summary of seeds computed by the NuRandomService
Random policy: 'random'
  master seed: 286039721
  seed within: [ 1 ; 900000000 ]
   Configured value          Last value   ModuleLabel.InstanceName
          700594431              (same)   IonAndScint.ISCalcAlg
          237756913              (same)   PDFastSim.photon
          587103144              (same)   PDFastSim.scinttime

%MSG

====================================================================================================
MemoryTracker summary (base-10 MB units used)

  Peak virtual memory usage (VmPeak)  : 9085.77 MB
  Peak resident set size usage (VmHWM): 7853.18 MB
====================================================================================================
```

With this change
```================================================================================================================================
TimeTracker printout (sec)                        Min           Avg           Max         Median          RMS         nEvts   
================================================================================================================================
Full event                                      92.693        92.693        92.693        92.693           0            1     
--------------------------------------------------------------------------------------------------------------------------------
source:RootInput(read)                        0.000332197   0.000332197   0.000332197   0.000332197        0            1     
simulate:rns:RandomNumberSaver                0.000131176   0.000131176   0.000131176   0.000131176        0            1     
simulate:IonAndScint:IonAndScint                1.10582       1.10582       1.10582       1.10582          0            1     
simulate:PDFastSim:PDFastSimPAR                 62.8539       62.8539       62.8539       62.8539          0            1     
[art]:TriggerResults:TriggerResultInserter    3.1845e-05    3.1845e-05    3.1845e-05    3.1845e-05         0            1     
end_path:out1:RootOutput                       1.031e-05     1.031e-05     1.031e-05     1.031e-05         0            1     
end_path:out1:RootOutput(write)                 28.7323       28.7323       28.7323       28.7323          0            1     
================================================================================================================================
%MSG-i NuRandomService:  RootOutput:out1@EndJob 07-Apr-2025 14:16:47 EDT  ModuleEndJob

Summary of seeds computed by the NuRandomService
Random policy: 'random'
  master seed: 585593786
  seed within: [ 1 ; 900000000 ]
   Configured value          Last value   ModuleLabel.InstanceName
           78603551              (same)   IonAndScint.ISCalcAlg
          387430349              (same)   PDFastSim.photon
          371449536              (same)   PDFastSim.scinttime

%MSG

====================================================================================================
MemoryTracker summary (base-10 MB units used)

  Peak virtual memory usage (VmPeak)  : 9541.87 MB
  Peak resident set size usage (VmHWM): 8504.03 MB
====================================================================================================```



I will make another pull request for the PhotonBackTracker in larsim, that appears to be the only other part of larsoft that needs to be changed