### PR TITLE
refactor (code change): include correct definition for member variable

### DIFF
--- a/lardataobj/RecoBase/Hit.h
+++ b/lardataobj/RecoBase/Hit.h
@@ -59,7 +59,7 @@ namespace recob {
     float
       fSigmaPeakAmplitude; ///< uncertainty on estimated amplitude of the hit at its peak, in ADC units
     float fROISummedADC; ///< the sum of calibrated ADC counts of the ROI
-    float fHitSummedADC; ///< the sum of calibrated ADC counts of the ROI
+    float fHitSummedADC; ///< the sum of calibrated ADC counts of the hit
     float
       fIntegral; ///< the integral under the calibrated signal waveform of the hit, in tick x ADC units
     float


### PR DESCRIPTION
Modify misleading comments for member variable:  `fHitSummedADC`.
The sum is concerning the whole hit, not the ROI.