### PR TITLE
Additional anab::Calorimetry with E-field and phi info

### DIFF
--- a/lardataobj/AnalysisBase/Calorimetry.cxx
+++ b/lardataobj/AnalysisBase/Calorimetry.cxx
@@ -160,13 +160,13 @@ namespace anab {
                            std::vector<anab::Point_t> const& XYZ,
                            std::vector<size_t> const& TpIndices,
                            geo::PlaneID planeID,
-			   std::vector<float> const& Efield,
-			   std::vector<float> const& Phi)
+                           std::vector<float> const& Efield,
+                           std::vector<float> const& Phi)
   {
 
     if (dEdx.size() != resRange.size() || dEdx.size() != dQdx.size() ||
         dEdx.size() != TrkPitch.size() || dEdx.size() != XYZ.size() ||
-	dEdx.size() != Efield.size() || dEdx.size() != Phi.size() ||
+        dEdx.size() != Efield.size() || dEdx.size() != Phi.size() ||
         (TpIndices.size() > 0 && dEdx.size() != TpIndices.size()))
       throw cet::exception("anab::Calorimetry") << "Input vectors "
                                                 << "have different sizes, this is a problem.\n";

--- a/lardataobj/AnalysisBase/Calorimetry.cxx
+++ b/lardataobj/AnalysisBase/Calorimetry.cxx
@@ -150,6 +150,41 @@ namespace anab {
   }
 
   //----------------------------------------------------------------------
+  Calorimetry::Calorimetry(float KineticEnergy,
+                           std::vector<float> const& dEdx,
+                           std::vector<float> const& dQdx,
+                           std::vector<float> const& resRange,
+                           std::vector<float> const& deadwire,
+                           float Range,
+                           std::vector<float> const& TrkPitch,
+                           std::vector<anab::Point_t> const& XYZ,
+                           std::vector<size_t> const& TpIndices,
+                           geo::PlaneID planeID,
+			   std::vector<float> const& Efield,
+			   std::vector<float> const& Phi)
+  {
+
+    if (dEdx.size() != resRange.size() || dEdx.size() != dQdx.size() ||
+        dEdx.size() != TrkPitch.size() || dEdx.size() != XYZ.size() ||
+	dEdx.size() != Efield.size() || dEdx.size() != Phi.size() ||
+        (TpIndices.size() > 0 && dEdx.size() != TpIndices.size()))
+      throw cet::exception("anab::Calorimetry") << "Input vectors "
+                                                << "have different sizes, this is a problem.\n";
+    fPlaneID = planeID;
+    fKineticEnergy = KineticEnergy;
+    fRange = Range;
+    fTrkPitch = TrkPitch;
+    fdEdx = dEdx;
+    fdQdx = dQdx;
+    fResidualRange = resRange;
+    fXYZ = XYZ;
+    fTpIndices = TpIndices;
+    fDeadWireResR = deadwire;
+    fEfield = Efield;
+    fPhi = Phi;
+  }
+
+  //----------------------------------------------------------------------
   // ostream operator.
   //
   std::ostream& operator<<(std::ostream& o, Calorimetry const& a)

--- a/lardataobj/AnalysisBase/Calorimetry.h
+++ b/lardataobj/AnalysisBase/Calorimetry.h
@@ -33,6 +33,8 @@ namespace anab {
     std::vector<Point_t>
       fXYZ; ///< coordinates of space points; for a discussion on the object type for coordinates see recob::tracking::Coord_t.
     std::vector<size_t> fTpIndices; ///< indices of original trajectory points on track
+    std::vector<float> fEfield; ///< E-field strength used for calorimetry
+    std::vector<float> fPhi; ///< track angle at each hit w.r.t. E-field, in degree
 
   private:
     geo::PlaneID fPlaneID;
@@ -77,6 +79,19 @@ namespace anab {
                 std::vector<size_t> const& TpIndices,
                 geo::PlaneID planeID);
 
+    Calorimetry(float KineticEnergy,
+                std::vector<float> const& dEdx,
+                std::vector<float> const& dQdx,
+                std::vector<float> const& resRange,
+                std::vector<float> const& deadwire,
+                float Range,
+                std::vector<float> const& TrkPitch,
+                std::vector<Point_t> const& XYZ,
+                std::vector<size_t> const& TpIndices,
+                geo::PlaneID planeID,
+		std::vector<float> const& Efield,
+                std::vector<float> const& Phi);
+
     friend std::ostream& operator<<(std::ostream& o, Calorimetry const& a);
 
     const std::vector<float>& dEdx() const;
@@ -90,6 +105,8 @@ namespace anab {
     const std::vector<Point_t>& XYZ() const;
     const std::vector<size_t>& TpIndices() const;
     const geo::PlaneID& PlaneID() const;
+    const std::vector<float>& Efield() const;
+    const std::vector<float>& Phi() const;
   };
 
 }
@@ -140,6 +157,14 @@ inline const std::vector<size_t>& anab::Calorimetry::TpIndices() const
 inline const geo::PlaneID& anab::Calorimetry::PlaneID() const
 {
   return fPlaneID;
+}
+inline const std::vector<float>& anab::Calorimetry::Efield() const
+{
+  return fEfield;
+}
+inline const std::vector<float>& anab::Calorimetry::Phi() const
+{
+  return fPhi;
 }
 
 #endif //ANAB_CALORIMETRY_H

--- a/lardataobj/AnalysisBase/Calorimetry.h
+++ b/lardataobj/AnalysisBase/Calorimetry.h
@@ -33,8 +33,8 @@ namespace anab {
     std::vector<Point_t>
       fXYZ; ///< coordinates of space points; for a discussion on the object type for coordinates see recob::tracking::Coord_t.
     std::vector<size_t> fTpIndices; ///< indices of original trajectory points on track
-    std::vector<float> fEfield; ///< E-field strength used for calorimetry
-    std::vector<float> fPhi; ///< track angle at each hit w.r.t. E-field, in degree
+    std::vector<float> fEfield;     ///< E-field strength used for calorimetry
+    std::vector<float> fPhi;        ///< track angle at each hit w.r.t. E-field, in degree
 
   private:
     geo::PlaneID fPlaneID;
@@ -89,7 +89,7 @@ namespace anab {
                 std::vector<Point_t> const& XYZ,
                 std::vector<size_t> const& TpIndices,
                 geo::PlaneID planeID,
-		std::vector<float> const& Efield,
+                std::vector<float> const& Efield,
                 std::vector<float> const& Phi);
 
     friend std::ostream& operator<<(std::ostream& o, Calorimetry const& a);

--- a/lardataobj/AnalysisBase/classes_def.xml
+++ b/lardataobj/AnalysisBase/classes_def.xml
@@ -99,7 +99,8 @@
  <enum name="anab::kVariableType"/>
  <enum name="anab::kTrackDir"/>
 
- <class name="anab::Calorimetry"           ClassVersion="17"                           >
+ <class name="anab::Calorimetry"           ClassVersion="18"                           >
+  <version ClassVersion="18" checksum="184829381"/>
   <version ClassVersion="17" checksum="836686545"/>
   <version ClassVersion="16" checksum="2995599306"/>
   <version ClassVersion="15" checksum="2095251371"/>


### PR DESCRIPTION
An additional anab:: Calorimetry with more hit info.
- Efield: E-field strength for a hit that is used for calorimetry based on recombination models.
- Phi: angle between track direction at a hit and E-field that is used for calorimetry based on angle dependent recombination models.

Adding these two values are essential for shifting recombination parameters and TPC gain calibration constant on flight at analysis level. This will make detector systematic studies much simpler.