### PR TITLE
Relocation of part of the utilities from TrackingTypes.h (issue #30090) [1/3]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ find_package(Boost REQUIRED EXPORT)
 find_package(ROOT COMPONENTS Core GenVector MathCore Matrix Physics REQUIRED EXPORT)
 
 find_package(larcoreobj REQUIRED EXPORT)
-find_package(larcorealg REQUIRED EXPORT)
 
 include(BuildDictionary)
 

--- a/lardataobj/RecoBase/CMakeLists.txt
+++ b/lardataobj/RecoBase/CMakeLists.txt
@@ -1,8 +1,7 @@
 cet_make_library(LIBRARY_NAME TrackingTypes INTERFACE
   SOURCE TrackingTypes.h
   LIBRARIES INTERFACE
-  larcorealg::Geometry
-  larcorealg::geo_vectors_utils
+  larcoreobj::geo_vectors
   ROOT::GenVector
   ROOT::Matrix
   ROOT::Physics

--- a/lardataobj/RecoBase/TrackingTypes.h
+++ b/lardataobj/RecoBase/TrackingTypes.h
@@ -2,7 +2,7 @@
 #define TRACKINGTYPE_H
 
 // LArSoft libraries
-#include "larcorealg/Geometry/geo_vectors_utils.h"
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
 
 // ROOT libraries
 #include "Math/GenVector/AxisAngle.h"
@@ -38,48 +38,6 @@ namespace recob {
 
     /// Type for representation of space rotations.
     using Rotation_t = ROOT::Math::Rotation3D;
-
-    /// @{
-    /// Tools to aide the conversion from TVector3 to Point_t and Vector_t
-    template <typename To, typename From>
-    std::vector<To> convertVec(std::vector<From> const& in)
-    {
-      std::vector<To> out;
-      out.reserve(in.size());
-      for (auto& i : in)
-        out.push_back(To(i));
-      return out;
-    }
-    template <typename From>
-    std::vector<TVector3> convertVecPointToTVec3(std::vector<From> const& in)
-    {
-      std::vector<TVector3> out;
-      out.reserve(in.size());
-      for (auto& i : in)
-        out.push_back(TVector3(i.X(), i.Y(), i.Z()));
-      return out;
-    }
-    template <typename Point>
-    Point_t toPoint(Point const& p)
-    {
-      return geo::vect::convertTo<Point_t>(p);
-    }
-    template <typename Point>
-    std::vector<Point_t> convertCollToPoint(std::vector<Point> const& coll)
-    {
-      return geo::vect::convertCollTo<Point_t>(coll);
-    }
-    template <typename Vector>
-    Vector_t toVector(Vector const& p)
-    {
-      return geo::vect::convertTo<Vector_t>(p);
-    }
-    template <typename Vector>
-    std::vector<Vector_t> convertCollToVector(std::vector<Vector> const& coll)
-    {
-      return geo::vect::convertCollTo<Vector_t>(coll);
-    }
-    /// @}
 
     /// A point in the trajectory, with position and momentum.
     struct TrajectoryPoint_t {

--- a/lardataobj/Simulation/SimEnergyDeposit.h
+++ b/lardataobj/Simulation/SimEnergyDeposit.h
@@ -115,10 +115,7 @@ namespace sim {
     double EndT() const { return endTime; }
 
     // Step mid-point.
-    geo::Point_t MidPoint() const
-    {
-      return startPos + 0.5 * (endPos - startPos);
-    }
+    geo::Point_t MidPoint() const { return startPos + 0.5 * (endPos - startPos); }
     geo::Length_t MidPointX() const { return (startPos.X() + endPos.X()) / 2.; }
     geo::Length_t MidPointY() const { return (startPos.Y() + endPos.Y()) / 2.; }
     geo::Length_t MidPointZ() const { return (startPos.Z() + endPos.Z()) / 2.; }

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -248,7 +248,6 @@ fwdir   product_dir    compatibility
 #
 ####################################
 product		version		qual	flags		<table_format=2>
-larcorealg	v10_00_03	-
 larcoreobj	v10_00_00	-
 nusimdata	v1_29_01	-
 cetmodules	v3_24_01	-	only_for_build
@@ -306,11 +305,11 @@ end_product_list
 #   case it is optional.
 #
 ####################################
-qualifier	larcoreobj	larcorealg	nusimdata
-c14:debug	c14:debug	c14:debug	c14:debug
-c14:prof	c14:prof	c14:prof	c14:prof
-e26:debug	e26:debug	e26:debug	e26:debug
-e26:prof	e26:prof	e26:prof	e26:prof
+qualifier	larcoreobj	nusimdata
+c14:debug	c14:debug	c14:debug
+c14:prof	c14:prof	c14:prof
+e26:debug	e26:debug	e26:debug
+e26:prof	e26:prof	e26:prof
 end_qualifier_list
 ####################################
 


### PR DESCRIPTION
This is the proposed resolution of [LArSoft issue #30090](https://cdcvs.fnal.gov/redmine/issues/30090).

The utilities depending on `lardataalg` functionality have been relocated from `lardataobj/Utilities/TrackingTypes.h` to the new header `lardataalg/Utilities/TrackingTypeUtils.h`.
One unused utility function has been removed (`convertVecPointToTVec3()`).

Three pull requests are involved:
 * LArSoft/lardataobj#54 (this one) removing the functions with unacceptable dependencies;
 * LArSoft/lardataalg#53 where those functions are moved to;
 * LArSoft/larreco#88 for fixes consequent to the breaking change.

## Conversion guide

This is technically a **breaking change**:

* If your program needs one of the utilities which have not changed location, you don't need to do anything
    * but the removal of `larcorealg::Geometry` dependency might expose an existing `CMakeLists.txt` bug, that may require the addition of `larcorealg::Geometry` in the `LIBRARIES` list of existing libraries as appropriate (or `ROOT::Hist` which was indirectly also provided). 
* If your program needs one of the relocated libraries:
    1. inculsion of the header `lardataalg/Utilities/TrackingTypeUtils.h` needs to be added (rarely, it can legitimately _replace_ `TrackingTypes.h` one);
    2. the library `lardataalg::UtilitiesHeaders` needs to be added to the library link list (`LIBRARIES`, choosing `PUBLIC`/`PRIVATE`/`INTERFACE` according to the usual rules).
* If your code needs `recob::tracking::convertVecPointToTVec3()`, report that need to LArSoft team since that function was deemed unused and therefore removed.

Pull requests have been opened in all LArSoft repositories where GitHub reports the usage of one of the functions (except `toPoint()`/`toVector()` which haven't been followed because of too many false positives).
Experiment code was not surveyed.
