### PR TITLE
Workaround for sim::IDE dictionary error spoiling current directory

### DIFF
--- a/lardataobj/Simulation/Compatibility/load_fixit_file.cxx
+++ b/lardataobj/Simulation/Compatibility/load_fixit_file.cxx
@@ -7,6 +7,7 @@ namespace {
   {
     cet::search_path const sp{"FW_SEARCH_PATH", std::nothrow};
     if (std::string filename; sp.find_file("simIDE_streamer_info.root", filename)) {
+      TDirectory::TContext cx;
       TFile file{filename.c_str()};
       return 0;
     }


### PR DESCRIPTION
Some magic was attempted to fix a ROOT issue hitting `sim::IDE` ROOT I/O schema evolution (explained in [a `README.md` file](https://github.com/LArSoft/lardataobj/blob/develop/lardataobj/Simulation/Compatibility/README.md)).
Because of that magic, when loading a ROOT file with objects from `lardataobj/Simulation` stored (`root test.root`), a message `Warning in <TClass::Init>: no dictionary for class sim::IDE is available` is printed, and the file appears not to be open (`.ls` will show nothing).

In order to have the streamer loaded into ROOT, the dictionary library was linked to `lardataobj::Simulation_Compatibility` library, which is using some static code to force ROOT load that streamer _by opening a ROOT file crafted to contain that streamer_ ¹. 

Matter of fact, the file is actually open (`_file0->cd()` will make it current), but the tragic coincidence of an unusual warning message and of not seeing the file data where it is expected has been enough to confuse most people (for years — the change was three years ago).

The workaround proposed here is making `root test.root` opened `test.root` "normally" (the warning is not addressed).
The magic recipe forced ROOT to load the `sim::IDE` streamer by opening a ROOT file and then immediately closing it. When a ROOT file is opened, the current ROOT directory is permanently changed away from the actual file on command line (`test.root`), then when the crafted file is closed the current directory is set to `gROOT` or something like that.
Here we just add a standard directory guard (`TDirectory::TContext`) to restore the current file properly.

Note that the warning can be triggered in `lardataobj` `v10_15_00` by just entering `sim::IDE ide;` on ROOT interpreter prompt.

--- 
¹ One guess is that the warning message stems from the fact that `lardataobj::Simulation_Compatibility` is loaded before `lardataobj::Simulation`, when no dictionary is yet present for `sim::IDE`. Or not.